### PR TITLE
Add PCF self-assessment tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.13-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# PCF Self-Assessment
+
+## Backend
+
+```bash
+# Build containers
+docker compose up --build -d
+# Run migrations
+docker compose exec web alembic upgrade head
+```
+
+Swagger UI will be at `http://localhost:8000/docs`.
+
+## Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The React app will be available at `http://localhost:5173`.

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,3 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = driver://user:pass@localhost/dbname

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,40 @@
+import os
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from app.models.models import Base
+
+config = context.config
+if config.config_file_name is not None:
+    try:
+        fileConfig(config.config_file_name)
+    except Exception:
+        pass
+
+DATABASE_URL = os.getenv('DATABASE_URL')
+config.set_main_option('sqlalchemy.url', DATABASE_URL)
+
+target_metadata = Base.metadata
+
+def run_migrations_offline():
+    url = config.get_main_option('sqlalchemy.url')
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix='sqlalchemy.',
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/0001_init.py
+++ b/alembic/versions/0001_init.py
@@ -1,0 +1,32 @@
+"""init
+
+Revision ID: 0001
+Revises: 
+Create Date: 2023-01-01 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'categories',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String, nullable=False)
+    )
+    op.create_table(
+        'processes',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String, nullable=False),
+        sa.Column('category_id', sa.Integer, sa.ForeignKey('categories.id'), nullable=False),
+        sa.Column('applicability', sa.Enum('MZ','WP','NZ', name='applicability'), nullable=False)
+    )
+
+def downgrade():
+    op.drop_table('processes')
+    op.drop_table('categories')
+    sa.Enum(name='applicability').drop(op.get_bind())

--- a/app/api/processes.py
+++ b/app/api/processes.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.core.db import get_db
+from app.models.models import Process
+from app.schemas import ProcessCreate, ProcessRead
+
+router = APIRouter(prefix="/api/processes", tags=["processes"])
+
+@router.post("/", response_model=ProcessRead)
+def create_process(process: ProcessCreate, db: Session = Depends(get_db)):
+    db_obj = Process(**process.dict())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+@router.get("/", response_model=List[ProcessRead])
+def list_processes(db: Session = Depends(get_db)):
+    return db.query(Process).all()

--- a/app/api/scoring.py
+++ b/app/api/scoring.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.core.db import get_db
+from app.models.models import Process, Applicability
+from app.schemas import ScoreInput
+
+router = APIRouter(prefix="/api/scoring", tags=["scoring"])
+
+@router.post("/")
+def score_processes(scores: List[ScoreInput], db: Session = Depends(get_db)):
+    results = []
+    for s in scores:
+        process = db.query(Process).get(s.process_id)
+        if not process or process.applicability == Applicability.NZ:
+            continue
+        values = [s.level_general, s.level_detailed]
+        if s.level_extension is not None:
+            values.append(s.level_extension)
+        avg = sum(values) / len(values)
+        results.append(avg)
+    overall = sum(results) / len(results) if results else 0
+    return {"overall": overall, "by_process": results}

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1,0 +1,14 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv('DATABASE_URL')
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+from app.api.processes import router as processes_router
+from app.api.scoring import router as scoring_router
+
+app = FastAPI()
+app.include_router(processes_router)
+app.include_router(scoring_router)

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -1,0 +1,22 @@
+from enum import Enum
+from sqlalchemy import Column, Integer, String, Enum as PgEnum, ForeignKey
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+class Applicability(str, Enum):
+    MZ = 'MZ'
+    WP = 'WP'
+    NZ = 'NZ'
+
+class Category(Base):
+    __tablename__ = 'categories'
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+
+class Process(Base):
+    __tablename__ = 'processes'
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    category_id = Column(Integer, ForeignKey('categories.id'), nullable=False)
+    applicability = Column(PgEnum(Applicability), nullable=False)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,22 @@
+from typing import Optional, List
+from pydantic import BaseModel
+from app.models.models import Applicability
+
+class ProcessBase(BaseModel):
+    name: str
+    category_id: int
+    applicability: Applicability
+
+class ProcessCreate(ProcessBase):
+    pass
+
+class ProcessRead(ProcessBase):
+    id: int
+    class Config:
+        orm_mode = True
+
+class ScoreInput(BaseModel):
+    process_id: int
+    level_general: int
+    level_detailed: int
+    level_extension: Optional[int] = None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: app
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - '5432:5432'
+  web:
+    build: .
+    environment:
+      DATABASE_URL: postgresql+psycopg2://user:password@db:5432/app
+    depends_on:
+      - db
+    ports:
+      - '8000:8000'
+volumes:
+  db_data:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PCF Self Assessment</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "pcf-self-assessment",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.4.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-hook-form": "^7.45.0",
+    "recharts": "^2.6.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "typescript": "^5.0.4",
+    "vite": "^4.3.9",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react'
+import GeneralForm from './components/GeneralForm'
+import ResultsView from './components/ResultsView'
+import { Process } from './types'
+
+export default function App() {
+  const [step, setStep] = useState<'general' | 'results'>('general')
+  const [processes, setProcesses] = useState<Process[]>([])
+  const [results, setResults] = useState<number[] | null>(null)
+
+  if (step === 'general') {
+    return (
+      <GeneralForm
+        processes={processes}
+        setProcesses={setProcesses}
+        onSubmit={(res) => {
+          setResults(res)
+          setStep('results')
+        }}
+      />
+    )
+  }
+  return <ResultsView results={results || []} />
+}

--- a/frontend/src/api/processes.ts
+++ b/frontend/src/api/processes.ts
@@ -1,0 +1,11 @@
+import axios from 'axios'
+import { Process } from '../types'
+
+const api = axios.create({ baseURL: '/api' })
+
+export const getProcesses = async (): Promise<Process[]> => {
+  const res = await api.get<Process[]>('/processes/')
+  return res.data
+}
+
+export default api

--- a/frontend/src/components/GeneralForm.tsx
+++ b/frontend/src/components/GeneralForm.tsx
@@ -1,0 +1,46 @@
+import { useEffect } from 'react'
+import { useForm, Controller } from 'react-hook-form'
+import { getProcesses } from '../api/processes'
+import { Applicability, Process } from '../types'
+
+interface Props {
+  processes: Process[]
+  setProcesses: (p: Process[]) => void
+  onSubmit: (results: number[]) => void
+}
+
+export default function GeneralForm({ processes, setProcesses, onSubmit }: Props) {
+  const { control, handleSubmit } = useForm<{ [key: number]: Applicability }>({})
+
+  useEffect(() => {
+    getProcesses().then(setProcesses)
+  }, [])
+
+  const submit = handleSubmit((data) => {
+    const values = Object.values(data).map((v) => (v === Applicability.NZ ? 0 : 1))
+    onSubmit(values)
+  })
+
+  return (
+    <form onSubmit={submit}>
+      {processes.map((p) => (
+        <div key={p.id}>
+          <label>{p.name}</label>
+          <Controller
+            name={String(p.id)}
+            control={control}
+            defaultValue={Applicability.MZ}
+            render={({ field }) => (
+              <select {...field}>
+                {Object.values(Applicability).map((a) => (
+                  <option key={a} value={a}>{a}</option>
+                ))}
+              </select>
+            )}
+          />
+        </div>
+      ))}
+      <button type="submit">Submit</button>
+    </form>
+  )
+}

--- a/frontend/src/components/ResultsView.tsx
+++ b/frontend/src/components/ResultsView.tsx
@@ -1,0 +1,25 @@
+import { BarChart, Bar, XAxis, YAxis } from 'recharts'
+
+interface Props {
+  results: number[]
+}
+
+export default function ResultsView({ results }: Props) {
+  const data = results.map((r, i) => ({ name: `P${i+1}`, value: r }))
+  return (
+    <div>
+      <table>
+        <tbody>
+          {data.map((d) => (
+            <tr key={d.name}><td>{d.name}</td><td>{d.value.toFixed(2)}</td></tr>
+          ))}
+        </tbody>
+      </table>
+      <BarChart width={300} height={200} data={data}>
+        <XAxis dataKey="name" />
+        <YAxis />
+        <Bar dataKey="value" fill="#8884d8" />
+      </BarChart>
+    </div>
+  )
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,12 @@
+export enum Applicability {
+  MZ = 'MZ',
+  WP = 'WP',
+  NZ = 'NZ'
+}
+
+export interface Process {
+  id: number
+  name: string
+  category_id: number
+  applicability: Applicability
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.app.json",
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+SQLAlchemy
+alembic
+psycopg2-binary
+pydantic


### PR DESCRIPTION
## Summary
- bootstrap FastAPI backend with SQLAlchemy and Alembic
- add Docker setup with PostgreSQL
- implement simple React/Vite frontend
- include initial Alembic migration

## Testing
- `pip install -r requirements.txt`
- `DATABASE_URL=sqlite:///./test.db PYTHONPATH=. alembic upgrade head`


------
https://chatgpt.com/codex/tasks/task_e_6853d4b8d97c8331ad24f6107d1ec324