### PR TITLE
Add API tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.pyo
+.test.db
+test.db
+.pytest_cache/

--- a/alembic/versions/0002_add_questions.py
+++ b/alembic/versions/0002_add_questions.py
@@ -1,0 +1,34 @@
+"""add questions and subcategories
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2023-01-02 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0002'
+down_revision = '0001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'subcategories',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=False),
+        sa.Column('name', sa.String, nullable=False),
+        sa.Column('category_id', sa.Integer, sa.ForeignKey('categories.id'), nullable=False)
+    )
+    op.create_table(
+        'questions',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=False),
+        sa.Column('category_id', sa.Integer, sa.ForeignKey('categories.id'), nullable=False),
+        sa.Column('subcategory_id', sa.Integer, sa.ForeignKey('subcategories.id'), nullable=False),
+        sa.Column('description', sa.String, nullable=False)
+    )
+
+
+def downgrade():
+    op.drop_table('questions')
+    op.drop_table('subcategories')

--- a/app/api/categories.py
+++ b/app/api/categories.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.core.db import get_db
+from app.models.models import Category
+from app.schemas import CategoryCreate, CategoryRead
+
+router = APIRouter(prefix="/api/categories", tags=["categories"])
+
+
+@router.post("/", response_model=CategoryRead)
+def create_category(category: CategoryCreate, db: Session = Depends(get_db)):
+    db_obj = Category(**category.dict())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+@router.get("/", response_model=List[CategoryRead])
+def list_categories(db: Session = Depends(get_db)):
+    return db.query(Category).all()

--- a/app/api/questions.py
+++ b/app/api/questions.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.core.db import get_db
+from app.models.models import Question
+from app.schemas import QuestionCreate, QuestionRead
+
+router = APIRouter(prefix="/api/questions", tags=["questions"])
+
+
+@router.post("/", response_model=QuestionRead)
+def create_question(question: QuestionCreate, db: Session = Depends(get_db)):
+    db_obj = Question(**question.dict())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+@router.get("/", response_model=List[QuestionRead])
+def list_questions(db: Session = Depends(get_db)):
+    return db.query(Question).all()

--- a/app/api/subcategories.py
+++ b/app/api/subcategories.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.core.db import get_db
+from app.models.models import Subcategory
+from app.schemas import SubcategoryCreate, SubcategoryRead
+
+router = APIRouter(prefix="/api/subcategories", tags=["subcategories"])
+
+
+@router.post("/", response_model=SubcategoryRead)
+def create_subcategory(subcat: SubcategoryCreate, db: Session = Depends(get_db)):
+    db_obj = Subcategory(**subcat.dict())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+@router.get("/", response_model=List[SubcategoryRead])
+def list_subcategories(db: Session = Depends(get_db)):
+    return db.query(Subcategory).all()

--- a/app/data_loader.py
+++ b/app/data_loader.py
@@ -1,0 +1,35 @@
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+
+from app.core.db import SessionLocal
+from app.models.models import Category, Subcategory, Question
+
+
+def _load_items(session, model, items: List[Dict[str, Any]]):
+    for item in items:
+        if session.get(model, item['id']) is None:
+            session.add(model(**item))
+
+
+def load_initial_data(path: str | Path | None = None) -> None:
+    """Load categories, subcategories and questions from YAML file."""
+    if os.getenv("SKIP_INIT_DATA"):
+        return
+    if path is None:
+        path = Path(os.getenv("INITIAL_DATA_PATH", Path(__file__).with_name("initial_data.yml")))
+    else:
+        path = Path(path)
+    if not path.exists():
+        return
+    data = yaml.safe_load(path.read_text()) or {}
+    session = SessionLocal()
+    try:
+        _load_items(session, Category, data.get("categories", []))
+        _load_items(session, Subcategory, data.get("subcategories", []))
+        _load_items(session, Question, data.get("questions", []))
+        session.commit()
+    finally:
+        session.close()

--- a/app/initial_data.yml
+++ b/app/initial_data.yml
@@ -1,0 +1,21 @@
+categories:
+  - id: 10
+    name: IT
+  - id: 20
+    name: HR
+subcategories:
+  - id: 10
+    name: Security
+    category_id: 10
+  - id: 20
+    name: Recruitment
+    category_id: 20
+questions:
+  - id: 10
+    category_id: 10
+    subcategory_id: 10
+    description: Do you use two-factor authentication?
+  - id: 20
+    category_id: 20
+    subcategory_id: 20
+    description: Do you have a hiring process?

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,22 @@
 from fastapi import FastAPI
 
+from app.data_loader import load_initial_data
+
 from app.api.processes import router as processes_router
 from app.api.scoring import router as scoring_router
+from app.api.categories import router as categories_router
+from app.api.subcategories import router as subcategories_router
+from app.api.questions import router as questions_router
 
 app = FastAPI()
+
+
+@app.on_event("startup")
+def _load_data() -> None:
+    load_initial_data()
+
 app.include_router(processes_router)
 app.include_router(scoring_router)
+app.include_router(categories_router)
+app.include_router(subcategories_router)
+app.include_router(questions_router)

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -20,3 +20,18 @@ class Process(Base):
     name = Column(String, nullable=False)
     category_id = Column(Integer, ForeignKey('categories.id'), nullable=False)
     applicability = Column(PgEnum(Applicability), nullable=False)
+
+
+class Subcategory(Base):
+    __tablename__ = 'subcategories'
+    id = Column(Integer, primary_key=True, autoincrement=False)
+    name = Column(String, nullable=False)
+    category_id = Column(Integer, ForeignKey('categories.id'), nullable=False)
+
+
+class Question(Base):
+    __tablename__ = 'questions'
+    id = Column(Integer, primary_key=True, autoincrement=False)
+    category_id = Column(Integer, ForeignKey('categories.id'), nullable=False)
+    subcategory_id = Column(Integer, ForeignKey('subcategories.id'), nullable=False)
+    description = Column(String, nullable=False)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -15,6 +15,51 @@ class ProcessRead(ProcessBase):
     class Config:
         orm_mode = True
 
+
+class CategoryBase(BaseModel):
+    id: int
+    name: str
+
+
+class CategoryCreate(CategoryBase):
+    pass
+
+
+class CategoryRead(CategoryBase):
+    class Config:
+        orm_mode = True
+
+
+class SubcategoryBase(BaseModel):
+    id: int
+    name: str
+    category_id: int
+
+
+class SubcategoryCreate(SubcategoryBase):
+    pass
+
+
+class SubcategoryRead(SubcategoryBase):
+    class Config:
+        orm_mode = True
+
+
+class QuestionBase(BaseModel):
+    id: int
+    category_id: int
+    subcategory_id: int
+    description: str
+
+
+class QuestionCreate(QuestionBase):
+    pass
+
+
+class QuestionRead(QuestionBase):
+    class Config:
+        orm_mode = True
+
 class ScoreInput(BaseModel):
     process_id: int
     level_general: int

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ SQLAlchemy
 alembic
 psycopg2-binary
 pydantic
+PyYAML

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,79 @@
+import os
+import sys
+os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
+os.environ['SKIP_INIT_DATA'] = '1'
+# ensure app package is importable
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from fastapi.testclient import TestClient
+import pytest
+
+from app.main import app
+from app.core.db import engine
+from app.models.models import Base
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+def test_create_and_list_categories(client):
+    resp = client.post('/api/categories/', json={'id': 1, 'name': 'Cat'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['id'] == 1
+    assert data['name'] == 'Cat'
+
+    resp = client.get('/api/categories/')
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+def test_create_subcategory(client):
+    client.post('/api/categories/', json={'id': 1, 'name': 'Cat'})
+    resp = client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub', 'category_id': 1})
+    assert resp.status_code == 200
+    resp = client.get('/api/subcategories/')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]['id'] == 1
+
+
+def test_create_question(client):
+    client.post('/api/categories/', json={'id': 1, 'name': 'Cat'})
+    client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub', 'category_id': 1})
+    resp = client.post('/api/questions/', json={
+        'id': 1,
+        'category_id': 1,
+        'subcategory_id': 1,
+        'description': 'Q1'
+    })
+    assert resp.status_code == 200
+    resp = client.get('/api/questions/')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+
+
+def test_score_processes(client):
+    client.post('/api/categories/', json={'id': 1, 'name': 'Cat'})
+    client.post('/api/processes/', json={'name': 'P1', 'category_id': 1, 'applicability': 'MZ'})
+    client.post('/api/processes/', json={'name': 'P2', 'category_id': 1, 'applicability': 'NZ'})
+    client.post('/api/processes/', json={'name': 'P3', 'category_id': 1, 'applicability': 'WP'})
+
+    payload = [
+        {'process_id': 1, 'level_general': 1, 'level_detailed': 2},
+        {'process_id': 2, 'level_general': 3, 'level_detailed': 4},
+        {'process_id': 3, 'level_general': 5, 'level_detailed': 5}
+    ]
+    resp = client.post('/api/scoring/', json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['by_process'] == [1.5, 5]
+    assert data['overall'] == pytest.approx(3.25)


### PR DESCRIPTION
## Summary
- create API tests for CRUD endpoints and scoring
- add `.gitignore` to clean up temporary data
- configure initial categories, subcategories and questions loaded at startup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853d941d3e483319d0a2a93850d6312