### PR TITLE
Update assessment logic

### DIFF
--- a/app/api/processes.py
+++ b/app/api/processes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
-from typing import List
+from typing import List, Optional
 
 from app.core.db import get_db
 from app.models.models import Process
@@ -17,5 +17,9 @@ def create_process(process: ProcessCreate, db: Session = Depends(get_db)):
     return db_obj
 
 @router.get("/", response_model=List[ProcessRead])
-def list_processes(db: Session = Depends(get_db)):
-    return db.query(Process).all()
+def list_processes(category_id: Optional[str] = None, db: Session = Depends(get_db)):
+    query = db.query(Process)
+    if category_id:
+        ids = [int(i) for i in category_id.split(',') if i]
+        query = query.filter(Process.category_id.in_(ids))
+    return query.all()

--- a/app/api/scoring.py
+++ b/app/api/scoring.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from typing import List
 
 from app.core.db import get_db
-from app.models.models import Process, Applicability
+from app.models.models import Process
 from app.schemas import ScoreInput
 
 router = APIRouter(prefix="/api/scoring", tags=["scoring"])
@@ -13,12 +13,8 @@ def score_processes(scores: List[ScoreInput], db: Session = Depends(get_db)):
     results = []
     for s in scores:
         process = db.query(Process).get(s.process_id)
-        if not process or process.applicability == Applicability.NZ:
+        if not process or s.score is None:
             continue
-        values = [s.level_general, s.level_detailed]
-        if s.level_extension is not None:
-            values.append(s.level_extension)
-        avg = sum(values) / len(values)
-        results.append(avg)
+        results.append(s.score)
     overall = sum(results) / len(results) if results else 0
     return {"overall": overall, "by_process": results}

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -1,13 +1,7 @@
-from enum import Enum
-from sqlalchemy import Column, Integer, String, Enum as PgEnum, ForeignKey
+from sqlalchemy import Column, Integer, String, ForeignKey
 from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()
-
-class Applicability(str, Enum):
-    MZ = 'MZ'
-    WP = 'WP'
-    NZ = 'NZ'
 
 class Category(Base):
     __tablename__ = 'categories'
@@ -19,7 +13,6 @@ class Process(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False)
     category_id = Column(Integer, ForeignKey('categories.id'), nullable=False)
-    applicability = Column(PgEnum(Applicability), nullable=False)
 
 
 class Subcategory(Base):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,11 +1,9 @@
-from typing import Optional, List
+from typing import Optional
 from pydantic import BaseModel
-from app.models.models import Applicability
 
 class ProcessBase(BaseModel):
     name: str
     category_id: int
-    applicability: Applicability
 
 class ProcessCreate(ProcessBase):
     pass
@@ -62,6 +60,4 @@ class QuestionRead(QuestionBase):
 
 class ScoreInput(BaseModel):
     process_id: int
-    level_general: int
-    level_detailed: int
-    level_extension: Optional[int] = None
+    score: Optional[int] = None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,34 @@
 import { useState } from 'react'
 import GeneralForm from './components/GeneralForm'
+import CategoryForm from './components/CategoryForm'
 import ResultsView from './components/ResultsView'
 import { Process } from './types'
 
 export default function App() {
-  const [step, setStep] = useState<'general' | 'results'>('general')
+  const [step, setStep] = useState<'start' | 'categories' | 'processes' | 'results'>('start')
+  const [selectedCategories, setSelectedCategories] = useState<number[]>([])
   const [processes, setProcesses] = useState<Process[]>([])
   const [results, setResults] = useState<number[] | null>(null)
 
-  if (step === 'general') {
+  if (step === 'start') {
+    return <button onClick={() => setStep('categories')}>Start</button>
+  }
+
+  if (step === 'categories') {
+    return (
+      <CategoryForm
+        onSubmit={(ids) => {
+          setSelectedCategories(ids)
+          setStep('processes')
+        }}
+      />
+    )
+  }
+
+  if (step === 'processes') {
     return (
       <GeneralForm
+        categoryIds={selectedCategories}
         processes={processes}
         setProcesses={setProcesses}
         onSubmit={(res) => {
@@ -20,5 +38,6 @@ export default function App() {
       />
     )
   }
+
   return <ResultsView results={results || []} />
 }

--- a/frontend/src/api/processes.ts
+++ b/frontend/src/api/processes.ts
@@ -3,8 +3,9 @@ import { Process } from '../types'
 
 const api = axios.create({ baseURL: '/api' })
 
-export const getProcesses = async (): Promise<Process[]> => {
-  const res = await api.get<Process[]>('/processes/')
+export const getProcesses = async (categories?: number[]): Promise<Process[]> => {
+  const params = categories && categories.length ? { category_id: categories.join(',') } : {}
+  const res = await api.get<Process[]>('/processes/', { params })
   return res.data
 }
 

--- a/frontend/src/components/CategoryForm.tsx
+++ b/frontend/src/components/CategoryForm.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect } from 'react'
+import { useForm, Controller } from 'react-hook-form'
+import axios from 'axios'
+import { Category } from '../types'
+
+interface Props {
+  onSubmit: (categoryIds: number[]) => void
+}
+
+export default function CategoryForm({ onSubmit }: Props) {
+  const { control, handleSubmit, watch } = useForm<Record<string, string>>({})
+  const [categories, setCategories] = React.useState<Category[]>([])
+
+  useEffect(() => {
+    axios.get<Category[]>('/api/categories/').then(res => setCategories(res.data))
+  }, [])
+
+  const submit = handleSubmit((data) => {
+    const ids: number[] = []
+    categories.forEach((c) => {
+      const applies = data[`applies_${c.id}`] === 'yes'
+      const implemented = data[`impl_${c.id}`] === 'yes'
+      const want = data[`want_${c.id}`] === 'yes'
+      if (applies && (implemented || want)) {
+        ids.push(c.id)
+      }
+    })
+    onSubmit(ids)
+  })
+
+  return (
+    <form onSubmit={submit}>
+      {categories.map(c => {
+        const applies = watch(`applies_${c.id}`)
+        const impl = watch(`impl_${c.id}`)
+        return (
+          <div key={c.id}>
+            <h3>{c.name}</h3>
+            <label>Czy ma zastosowanie?</label>
+            <Controller
+              name={`applies_${c.id}`}
+              control={control}
+              defaultValue="no"
+              render={({ field }) => (
+                <select {...field}>
+                  <option value="yes">Tak</option>
+                  <option value="no">Nie</option>
+                </select>
+              )}
+            />
+            {applies === 'yes' && (
+              <>
+                <label>Czy organizacja realizuje u siebie te procesy?</label>
+                <Controller
+                  name={`impl_${c.id}`}
+                  control={control}
+                  defaultValue="no"
+                  render={({ field }) => (
+                    <select {...field}>
+                      <option value="yes">Tak</option>
+                      <option value="no">Nie</option>
+                    </select>
+                  )}
+                />
+                {impl === 'no' && (
+                  <>
+                    <label>Czy organizacja chciałaby je realizować?</label>
+                    <Controller
+                      name={`want_${c.id}`}
+                      control={control}
+                      defaultValue="no"
+                      render={({ field }) => (
+                        <select {...field}>
+                          <option value="yes">Tak</option>
+                          <option value="no">Nie</option>
+                        </select>
+                      )}
+                    />
+                  </>
+                )}
+              </>
+            )}
+          </div>
+        )
+      })}
+      <button type="submit">Dalej</button>
+    </form>
+  )
+}

--- a/frontend/src/components/GeneralForm.tsx
+++ b/frontend/src/components/GeneralForm.tsx
@@ -7,14 +7,15 @@ interface Props {
   processes: Process[]
   setProcesses: (p: Process[]) => void
   onSubmit: (results: number[]) => void
+  categoryIds: number[]
 }
 
-export default function GeneralForm({ processes, setProcesses, onSubmit }: Props) {
+export default function GeneralForm({ processes, setProcesses, onSubmit, categoryIds }: Props) {
   const { control, handleSubmit } = useForm<Record<string, string>>({})
 
   useEffect(() => {
-    getProcesses().then(setProcesses)
-  }, [])
+    getProcesses(categoryIds).then(setProcesses)
+  }, [categoryIds])
 
   const submit = handleSubmit((data) => {
     const values = Object.values(data).map((v) => (v === 'NA' ? 0 : Number(v)))

--- a/frontend/src/components/GeneralForm.tsx
+++ b/frontend/src/components/GeneralForm.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { useForm, Controller } from 'react-hook-form'
 import { getProcesses } from '../api/processes'
-import { Applicability, Process } from '../types'
+import { Process } from '../types'
 
 interface Props {
   processes: Process[]
@@ -10,14 +10,14 @@ interface Props {
 }
 
 export default function GeneralForm({ processes, setProcesses, onSubmit }: Props) {
-  const { control, handleSubmit } = useForm<Record<string, Applicability>>({})
+  const { control, handleSubmit } = useForm<Record<string, string>>({})
 
   useEffect(() => {
     getProcesses().then(setProcesses)
   }, [])
 
   const submit = handleSubmit((data) => {
-    const values = Object.values(data).map((v) => (v === Applicability.NZ ? 0 : 1))
+    const values = Object.values(data).map((v) => (v === 'NA' ? 0 : Number(v)))
     onSubmit(values)
   })
 
@@ -29,11 +29,12 @@ export default function GeneralForm({ processes, setProcesses, onSubmit }: Props
           <Controller
             name={String(p.id)}
             control={control}
-            defaultValue={Applicability.MZ}
+            defaultValue="NA"
             render={({ field }) => (
               <select {...field}>
-                {Object.values(Applicability).map((a) => (
-                  <option key={a} value={a}>{a}</option>
+                <option value="NA">N/A</option>
+                {[1,2,3,4,5].map((n) => (
+                  <option key={n} value={n}>{n}</option>
                 ))}
               </select>
             )}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -3,3 +3,8 @@ export interface Process {
   name: string
   category_id: number
 }
+
+export interface Category {
+  id: number
+  name: string
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,12 +1,5 @@
-export enum Applicability {
-  MZ = 'MZ',
-  WP = 'WP',
-  NZ = 'NZ'
-}
-
 export interface Process {
   id: number
   name: string
   category_id: number
-  applicability: Applicability
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -63,17 +63,17 @@ def test_create_question(client):
 
 def test_score_processes(client):
     client.post('/api/categories/', json={'id': 1, 'name': 'Cat'})
-    client.post('/api/processes/', json={'name': 'P1', 'category_id': 1, 'applicability': 'MZ'})
-    client.post('/api/processes/', json={'name': 'P2', 'category_id': 1, 'applicability': 'NZ'})
-    client.post('/api/processes/', json={'name': 'P3', 'category_id': 1, 'applicability': 'WP'})
+    client.post('/api/processes/', json={'name': 'P1', 'category_id': 1})
+    client.post('/api/processes/', json={'name': 'P2', 'category_id': 1})
+    client.post('/api/processes/', json={'name': 'P3', 'category_id': 1})
 
     payload = [
-        {'process_id': 1, 'level_general': 1, 'level_detailed': 2},
-        {'process_id': 2, 'level_general': 3, 'level_detailed': 4},
-        {'process_id': 3, 'level_general': 5, 'level_detailed': 5}
+        {'process_id': 1, 'score': 1},
+        {'process_id': 2, 'score': None},
+        {'process_id': 3, 'score': 5}
     ]
     resp = client.post('/api/scoring/', json=payload)
     assert resp.status_code == 200
     data = resp.json()
-    assert data['by_process'] == [1.5, 5]
-    assert data['overall'] == pytest.approx(3.25)
+    assert data['by_process'] == [1, 5]
+    assert data['overall'] == pytest.approx(3)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -77,3 +77,16 @@ def test_score_processes(client):
     data = resp.json()
     assert data['by_process'] == [1, 5]
     assert data['overall'] == pytest.approx(3)
+
+
+def test_list_processes_by_category(client):
+    client.post('/api/categories/', json={'id': 1, 'name': 'Cat1'})
+    client.post('/api/categories/', json={'id': 2, 'name': 'Cat2'})
+    client.post('/api/processes/', json={'name': 'P1', 'category_id': 1})
+    client.post('/api/processes/', json={'name': 'P2', 'category_id': 2})
+
+    resp = client.get('/api/processes/', params={'category_id': '1'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]['category_id'] == 1


### PR DESCRIPTION
## Summary
- refactor models to drop Applicability enum and column
- simplify schemas and scoring API to use a single optional score
- adjust frontend form for 1‑5 or N/A answers
- update tests for new scoring logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853ed94f2b08331aa74eeb4c8c072ee