### PR TITLE
Fix frontend API routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ npm run dev
 ```
 
 The React app will be available at `http://localhost:5173`.
+All requests to `/api` will be proxied to the backend running on
+`http://localhost:8000`, so make sure the backend is running when using the
+development server.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,13 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
   }
 })


### PR DESCRIPTION
## Summary
- proxy `/api` requests from Vite dev server to the backend
- note proxy requirement in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853f8877db483318d7c3f1f59e5cb08