### PR TITLE
Add React Bootstrap UI and clear defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,2 @@
+All frontend components use React Bootstrap for styling.
+Import `'bootstrap/dist/css/bootstrap.min.css'` in `frontend/src/main.tsx` and use `react-bootstrap` components such as `Form`, `Button`, and `Container` instead of raw HTML tags wherever possible.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,9 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.45.0",
-    "recharts": "^2.6.2"
+    "recharts": "^2.6.2",
+    "react-bootstrap": "^2.9.2",
+    "bootstrap": "^5.3.2"
   },
   "devDependencies": {
     "@types/lodash": "^4.17.18",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import GeneralForm from './components/GeneralForm'
 import CategoryForm from './components/CategoryForm'
 import ResultsView from './components/ResultsView'
 import { Question } from './types'
+import { Container, Button } from 'react-bootstrap'
 
 export default function App() {
   const [step, setStep] = useState<'start' | 'categories' | 'questions' | 'results'>('start')
@@ -11,33 +12,45 @@ export default function App() {
   const [results, setResults] = useState<number[] | null>(null)
 
   if (step === 'start') {
-    return <button onClick={() => setStep('categories')}>Start</button>
+    return (
+      <Container className="text-center mt-5">
+        <Button onClick={() => setStep('categories')}>Start</Button>
+      </Container>
+    )
   }
 
   if (step === 'categories') {
     return (
-      <CategoryForm
-        onSubmit={(ids) => {
-          setSelectedCategories(ids)
-          setStep('questions')
-        }}
-      />
+      <Container className="mt-4">
+        <CategoryForm
+          onSubmit={(ids) => {
+            setSelectedCategories(ids)
+            setStep('questions')
+          }}
+        />
+      </Container>
     )
   }
 
   if (step === 'questions') {
     return (
-      <GeneralForm
-        categoryIds={selectedCategories}
-        questions={questions}
-        setQuestions={setQuestions}
-        onSubmit={(res) => {
-          setResults(res)
-          setStep('results')
-        }}
-      />
+      <Container className="mt-4">
+        <GeneralForm
+          categoryIds={selectedCategories}
+          questions={questions}
+          setQuestions={setQuestions}
+          onSubmit={(res) => {
+            setResults(res)
+            setStep('results')
+          }}
+        />
+      </Container>
     )
   }
 
-  return <ResultsView results={results || []} />
+  return (
+    <Container className="mt-4">
+      <ResultsView results={results || []} />
+    </Container>
+  )
 }

--- a/frontend/src/components/CategoryForm.tsx
+++ b/frontend/src/components/CategoryForm.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 import { useForm, Controller } from 'react-hook-form'
 import axios from 'axios'
 import { Category } from '../types'
+import { Form, Button } from 'react-bootstrap'
 
 interface Props {
   onSubmit: (categoryIds: number[]) => void
@@ -29,51 +30,54 @@ export default function CategoryForm({ onSubmit }: Props) {
   })
 
   return (
-    <form onSubmit={submit}>
-      {categories.map(c => {
+    <Form onSubmit={submit}>
+      {categories.map((c) => {
         const applies = watch(`applies_${c.id}`)
         const impl = watch(`impl_${c.id}`)
         return (
-          <div key={c.id}>
+          <div key={c.id} className="mb-3">
             <h3>{c.name}</h3>
-            <label>Czy ma zastosowanie?</label>
+            <Form.Label>Czy ma zastosowanie?</Form.Label>
             <Controller
               name={`applies_${c.id}`}
               control={control}
-              defaultValue="no"
+              defaultValue=""
               render={({ field }) => (
-                <select {...field}>
+                <Form.Select {...field}>
+                  <option value="">-- wybierz --</option>
                   <option value="yes">Tak</option>
                   <option value="no">Nie</option>
-                </select>
+                </Form.Select>
               )}
             />
             {applies === 'yes' && (
               <>
-                <label>Czy organizacja realizuje u siebie te procesy?</label>
+                <Form.Label className="mt-2">Czy organizacja realizuje u siebie te procesy?</Form.Label>
                 <Controller
                   name={`impl_${c.id}`}
                   control={control}
-                  defaultValue="no"
+                  defaultValue=""
                   render={({ field }) => (
-                    <select {...field}>
+                    <Form.Select {...field}>
+                      <option value="">-- wybierz --</option>
                       <option value="yes">Tak</option>
                       <option value="no">Nie</option>
-                    </select>
+                    </Form.Select>
                   )}
                 />
                 {impl === 'no' && (
                   <>
-                    <label>Czy organizacja chciałaby je realizować?</label>
+                    <Form.Label className="mt-2">Czy organizacja chciałaby je realizować?</Form.Label>
                     <Controller
                       name={`want_${c.id}`}
                       control={control}
-                      defaultValue="no"
+                      defaultValue=""
                       render={({ field }) => (
-                        <select {...field}>
+                        <Form.Select {...field}>
+                          <option value="">-- wybierz --</option>
                           <option value="yes">Tak</option>
                           <option value="no">Nie</option>
-                        </select>
+                        </Form.Select>
                       )}
                     />
                   </>
@@ -83,7 +87,7 @@ export default function CategoryForm({ onSubmit }: Props) {
           </div>
         )
       })}
-      <button type="submit">Dalej</button>
-    </form>
+      <Button type="submit">Dalej</Button>
+    </Form>
   )
 }

--- a/frontend/src/components/GeneralForm.tsx
+++ b/frontend/src/components/GeneralForm.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useForm, Controller } from 'react-hook-form'
 import { getQuestions } from '../api/questions'
 import { Question } from '../types'
+import { Form, Button } from 'react-bootstrap'
 
 interface Props {
   questions: Question[]
@@ -23,26 +24,27 @@ export default function GeneralForm({ questions, setQuestions, onSubmit, categor
   })
 
   return (
-    <form onSubmit={submit}>
+    <Form onSubmit={submit}>
       {questions.map((q) => (
-        <div key={q.id}>
-          <label>{q.description}</label>
+        <div key={q.id} className="mb-3">
+          <Form.Label>{q.description}</Form.Label>
           <Controller
             name={String(q.id)}
             control={control}
-            defaultValue="NA"
+            defaultValue=""
             render={({ field }) => (
-              <select {...field}>
+              <Form.Select {...field}>
+                <option value="">-- wybierz --</option>
                 <option value="NA">N/A</option>
-                {[1,2,3,4,5].map((n) => (
+                {[1, 2, 3, 4, 5].map((n) => (
                   <option key={n} value={n}>{n}</option>
                 ))}
-              </select>
+              </Form.Select>
             )}
           />
         </div>
       ))}
-      <button type="submit">Submit</button>
-    </form>
+      <Button type="submit">Submit</Button>
+    </Form>
   )
 }

--- a/frontend/src/components/ResultsView.tsx
+++ b/frontend/src/components/ResultsView.tsx
@@ -1,4 +1,5 @@
 import { BarChart, Bar, XAxis, YAxis } from 'recharts'
+import { Table } from 'react-bootstrap'
 
 interface Props {
   results: number[]
@@ -8,13 +9,13 @@ export default function ResultsView({ results }: Props) {
   const data = results.map((r, i) => ({ name: `P${i+1}`, value: r }))
   return (
     <div>
-      <table>
+      <Table striped bordered size="sm" className="w-auto">
         <tbody>
           {data.map((d) => (
             <tr key={d.name}><td>{d.name}</td><td>{d.value.toFixed(2)}</td></tr>
           ))}
         </tbody>
-      </table>
+      </Table>
       <BarChart width={300} height={200} data={data}>
         <XAxis dataKey="name" />
         <YAxis />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import 'bootstrap/dist/css/bootstrap.min.css'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- introduce React Bootstrap to style frontend
- clear default selections on category and question forms
- use React Bootstrap components across UI
- document new frontend framework in `AGENTS.md`

## Testing
- `npm install`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685439cf095c83319b92e78f7bff5f50