### PR TITLE
Use composite keys for IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,2 +1,8 @@
 All frontend components use React Bootstrap for styling.
 Import `'bootstrap/dist/css/bootstrap.min.css'` in `frontend/src/main.tsx` and use `react-bootstrap` components such as `Form`, `Button`, and `Container` instead of raw HTML tags wherever possible.
+
+Frontend guidelines for the question flow:
+- Questions are grouped first by category and then by subcategory.
+- Each category is shown on its own page with a progress bar indicating how many categories have been completed.
+- Subcategories display their name and description before the related questions and are visually separated using React Bootstrap components such as `Card` or `ListGroup`.
+- Each question shows a description and optional details. Answers are collected on a 1–5 radio-button scale with a colour coded „Nie dotyczy” option.

--- a/app/api/subcategories.py
+++ b/app/api/subcategories.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
-from typing import List
+from typing import List, Optional
 
 from app.core.db import get_db
 from app.models.models import Subcategory
@@ -19,5 +19,11 @@ def create_subcategory(subcat: SubcategoryCreate, db: Session = Depends(get_db))
 
 
 @router.get("/", response_model=List[SubcategoryRead])
-def list_subcategories(db: Session = Depends(get_db)):
-    return db.query(Subcategory).all()
+def list_subcategories(
+    category_id: Optional[str] = None, db: Session = Depends(get_db)
+):
+    query = db.query(Subcategory)
+    if category_id:
+        ids = [int(i) for i in category_id.split(",") if i]
+        query = query.filter(Subcategory.category_id.in_(ids))
+    return query.all()

--- a/app/data_loader.py
+++ b/app/data_loader.py
@@ -4,13 +4,20 @@ from typing import Any, Dict, List
 
 import yaml
 
+from sqlalchemy import inspect
+
 from app.core.db import SessionLocal, engine
 from app.models.models import Base, Category, Subcategory, Question
 
 
 def _load_items(session, model, items: List[Dict[str, Any]]):
+    inspector = inspect(model)
+    pk_cols = [c.name for c in inspector.primary_key]
     for item in items:
-        if session.get(model, item['id']) is None:
+        key = tuple(item[col] for col in pk_cols)
+        if len(pk_cols) == 1:
+            key = key[0]
+        if session.get(model, key) is None:
             session.add(model(**item))
 
 

--- a/app/initial_data.yml
+++ b/app/initial_data.yml
@@ -1,21 +1,25 @@
 categories:
-  - id: 10
+  - id: 1
     name: IT
-  - id: 20
+  - id: 2
     name: HR
 subcategories:
-  - id: 10
+  - id: 1
+    category_id: 1
     name: Security
-    category_id: 10
-  - id: 20
+    description: Security-related operations
+  - id: 1
+    category_id: 2
     name: Recruitment
-    category_id: 20
+    description: Processes for hiring staff
 questions:
-  - id: 10
-    category_id: 10
-    subcategory_id: 10
+  - id: 1
+    category_id: 1
+    subcategory_id: 1
     description: Do you use two-factor authentication?
-  - id: 20
-    category_id: 20
-    subcategory_id: 20
+    details: Additional authentication mechanisms are recommended.
+  - id: 1
+    category_id: 2
+    subcategory_id: 1
     description: Do you have a hiring process?
+    details: Outline of recruitment steps.

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -3,28 +3,36 @@ from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()
 
+
 class Category(Base):
-    __tablename__ = 'categories'
+    __tablename__ = "categories"
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False)
 
+
 class Process(Base):
-    __tablename__ = 'processes'
+    __tablename__ = "processes"
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False)
-    category_id = Column(Integer, ForeignKey('categories.id'), nullable=False)
+    category_id = Column(Integer, ForeignKey("categories.id"), nullable=False)
 
 
 class Subcategory(Base):
-    __tablename__ = 'subcategories'
+    __tablename__ = "subcategories"
+    # identifier of subcategory is local to its category so we use a composite
+    # primary key
     id = Column(Integer, primary_key=True, autoincrement=False)
+    category_id = Column(Integer, ForeignKey("categories.id"), primary_key=True)
     name = Column(String, nullable=False)
-    category_id = Column(Integer, ForeignKey('categories.id'), nullable=False)
+    description = Column(String, nullable=True)
 
 
 class Question(Base):
-    __tablename__ = 'questions'
+    __tablename__ = "questions"
+    # question numbering restarts for each subcategory so we use a composite
+    # primary key from category, subcategory and the question id
     id = Column(Integer, primary_key=True, autoincrement=False)
-    category_id = Column(Integer, ForeignKey('categories.id'), nullable=False)
-    subcategory_id = Column(Integer, ForeignKey('subcategories.id'), nullable=False)
+    category_id = Column(Integer, ForeignKey("categories.id"), primary_key=True)
+    subcategory_id = Column(Integer, ForeignKey("subcategories.id"), primary_key=True)
     description = Column(String, nullable=False)
+    details = Column(String, nullable=True)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,15 +1,19 @@
 from typing import Optional
 from pydantic import BaseModel
 
+
 class ProcessBase(BaseModel):
     name: str
     category_id: int
 
+
 class ProcessCreate(ProcessBase):
     pass
 
+
 class ProcessRead(ProcessBase):
     id: int
+
     class Config:
         orm_mode = True
 
@@ -32,6 +36,7 @@ class SubcategoryBase(BaseModel):
     id: int
     name: str
     category_id: int
+    description: Optional[str] = None
 
 
 class SubcategoryCreate(SubcategoryBase):
@@ -48,6 +53,7 @@ class QuestionBase(BaseModel):
     category_id: int
     subcategory_id: int
     description: str
+    details: Optional[str] = None
 
 
 class QuestionCreate(QuestionBase):
@@ -57,6 +63,7 @@ class QuestionCreate(QuestionBase):
 class QuestionRead(QuestionBase):
     class Config:
         orm_mode = True
+
 
 class ScoreInput(BaseModel):
     process_id: int

--- a/frontend/src/api/categories.ts
+++ b/frontend/src/api/categories.ts
@@ -1,0 +1,11 @@
+import axios from 'axios'
+import { Category } from '../types'
+
+const api = axios.create({ baseURL: '/api' })
+
+export const getCategories = async (): Promise<Category[]> => {
+  const res = await api.get<Category[]>('/categories/')
+  return res.data
+}
+
+export default api

--- a/frontend/src/api/subcategories.ts
+++ b/frontend/src/api/subcategories.ts
@@ -1,0 +1,12 @@
+import axios from 'axios'
+import { Subcategory } from '../types'
+
+const api = axios.create({ baseURL: '/api' })
+
+export const getSubcategories = async (categoryIds?: number[]): Promise<Subcategory[]> => {
+  const params = categoryIds && categoryIds.length ? { category_id: categoryIds.join(',') } : {}
+  const res = await api.get<Subcategory[]>('/subcategories/', { params })
+  return res.data
+}
+
+export default api

--- a/frontend/src/components/GeneralForm.tsx
+++ b/frontend/src/components/GeneralForm.tsx
@@ -1,8 +1,10 @@
-import { useEffect } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { useForm, Controller } from 'react-hook-form'
 import { getQuestions } from '../api/questions'
-import { Question } from '../types'
-import { Form, Button } from 'react-bootstrap'
+import { getCategories } from '../api/categories'
+import { getSubcategories } from '../api/subcategories'
+import { Question, Category, Subcategory } from '../types'
+import { Form, Button, ProgressBar, Card } from 'react-bootstrap'
 
 interface Props {
   questions: Question[]
@@ -13,38 +15,114 @@ interface Props {
 
 export default function GeneralForm({ questions, setQuestions, onSubmit, categoryIds }: Props) {
   const { control, handleSubmit } = useForm<Record<string, string>>({})
+  const [categories, setCategories] = useState<Category[]>([])
+  const [subcats, setSubcats] = useState<Subcategory[]>([])
+  const [page, setPage] = useState(0)
 
   useEffect(() => {
     getQuestions(categoryIds).then(setQuestions)
+    getCategories().then(setCategories)
+    getSubcategories(categoryIds).then(setSubcats)
   }, [categoryIds])
+
+  const grouped = useMemo(() => {
+    const map: Record<number, Record<number, Question[]>> = {}
+    questions.forEach((q) => {
+      if (!map[q.category_id]) map[q.category_id] = {}
+      if (!map[q.category_id][q.subcategory_id]) map[q.category_id][q.subcategory_id] = []
+      map[q.category_id][q.subcategory_id].push(q)
+    })
+    return categoryIds.map((id) => ({
+      id,
+      name: categories.find((c) => c.id === id)?.name || `Category ${id}`,
+      subcategories: subcats
+        .filter((s) => s.category_id === id)
+        .map((s) => ({
+          ...s,
+          questions: map[id]?.[s.id] || []
+        }))
+    }))
+  }, [questions, categoryIds, categories, subcats])
 
   const submit = handleSubmit((data) => {
     const values = Object.values(data).map((v) => (v === 'NA' ? 0 : Number(v)))
     onSubmit(values)
   })
 
+  const current = grouped[page]
+  const total = grouped.length
+  const progress = Math.round((page / total) * 100)
+
   return (
     <Form onSubmit={submit}>
-      {questions.map((q) => (
-        <div key={q.id} className="mb-3">
-          <Form.Label>{q.description}</Form.Label>
-          <Controller
-            name={String(q.id)}
-            control={control}
-            defaultValue=""
-            render={({ field }) => (
-              <Form.Select {...field}>
-                <option value="">-- wybierz --</option>
-                <option value="NA">N/A</option>
-                {[1, 2, 3, 4, 5].map((n) => (
-                  <option key={n} value={n}>{n}</option>
-                ))}
-              </Form.Select>
+      <ProgressBar now={progress} label={`${page}/${total}`} className="mb-3" />
+      <h4 className="mb-3">{current?.name}</h4>
+      {current?.subcategories.map((sc) => (
+        <Card key={sc.id} className="mb-4">
+          <Card.Body>
+            <Card.Title>{sc.name}</Card.Title>
+            {sc.description && (
+              <Card.Text className="text-muted">{sc.description}</Card.Text>
             )}
-          />
-        </div>
+            {sc.questions.map((q) => (
+              <div key={q.id} className="mb-3">
+                <Form.Label><strong>{q.description}</strong></Form.Label>
+                {q.details && (
+                  <div className="text-muted small mb-2">{q.details}</div>
+                )}
+                <Controller
+                  name={String(q.id)}
+                  control={control}
+                  defaultValue=""
+                  render={({ field }) => (
+                    <div>
+                      <div className="d-flex align-items-center mb-1">
+                        {[1, 2, 3, 4, 5].map((n) => (
+                          <Form.Check
+                            key={n}
+                            inline
+                            type="radio"
+                            id={`${q.id}_${n}`}
+                            label={n}
+                            value={n}
+                            checked={field.value === String(n)}
+                            onChange={() => field.onChange(String(n))}
+                          />
+                        ))}
+                        <Form.Check
+                          inline
+                          type="radio"
+                          id={`${q.id}_na`}
+                          label="Nie dotyczy"
+                          value="NA"
+                          checked={field.value === 'NA'}
+                          onChange={() => field.onChange('NA')}
+                          className="ms-3 text-secondary"
+                        />
+                      </div>
+                      <div className="small text-muted">Skala 1-5 - lorem ipsum</div>
+                    </div>
+                  )}
+                />
+              </div>
+            ))}
+          </Card.Body>
+        </Card>
       ))}
-      <Button type="submit">Submit</Button>
+      <div className="d-flex justify-content-between">
+        {page > 0 && (
+          <Button variant="secondary" onClick={() => setPage(page - 1)}>
+            Wstecz
+          </Button>
+        )}
+        {page < total - 1 ? (
+          <Button onClick={() => setPage(page + 1)}>
+            Dalej
+          </Button>
+        ) : (
+          <Button type="submit">Zatwierdź</Button>
+        )}
+      </div>
     </Form>
   )
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -9,6 +9,14 @@ export interface Question {
   description: string
   category_id: number
   subcategory_id: number
+  details?: string
+}
+
+export interface Subcategory {
+  id: number
+  category_id: number
+  name: string
+  description?: string
 }
 
 export interface Category {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,10 @@
 import os
 import sys
-os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
-os.environ['SKIP_INIT_DATA'] = '1'
+
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+os.environ["SKIP_INIT_DATA"] = "1"
 # ensure app package is importable
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fastapi.testclient import TestClient
 import pytest
@@ -12,97 +13,187 @@ from app.main import app
 from app.core.db import engine
 from app.models.models import Base
 
+
 @pytest.fixture(autouse=True)
 def setup_db():
     Base.metadata.drop_all(bind=engine)
     Base.metadata.create_all(bind=engine)
     yield
 
+
 @pytest.fixture
 def client():
     with TestClient(app) as c:
         yield c
 
+
 def test_create_and_list_categories(client):
-    resp = client.post('/api/categories/', json={'id': 1, 'name': 'Cat'})
+    resp = client.post("/api/categories/", json={"id": 1, "name": "Cat"})
     assert resp.status_code == 200
     data = resp.json()
-    assert data['id'] == 1
-    assert data['name'] == 'Cat'
+    assert data["id"] == 1
+    assert data["name"] == "Cat"
 
-    resp = client.get('/api/categories/')
+    resp = client.get("/api/categories/")
     assert resp.status_code == 200
     assert len(resp.json()) == 1
 
+
 def test_create_subcategory(client):
-    client.post('/api/categories/', json={'id': 1, 'name': 'Cat'})
-    resp = client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub', 'category_id': 1})
+    client.post("/api/categories/", json={"id": 1, "name": "Cat"})
+    resp = client.post(
+        "/api/subcategories/",
+        json={"id": 1, "name": "Sub", "category_id": 1, "description": "desc"},
+    )
     assert resp.status_code == 200
-    resp = client.get('/api/subcategories/')
+    resp = client.get("/api/subcategories/")
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 1
-    assert data[0]['id'] == 1
+    assert data[0]["id"] == 1
 
 
 def test_create_question(client):
-    client.post('/api/categories/', json={'id': 1, 'name': 'Cat'})
-    client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub', 'category_id': 1})
-    resp = client.post('/api/questions/', json={
-        'id': 1,
-        'category_id': 1,
-        'subcategory_id': 1,
-        'description': 'Q1'
-    })
+    client.post("/api/categories/", json={"id": 1, "name": "Cat"})
+    client.post(
+        "/api/subcategories/",
+        json={"id": 1, "name": "Sub", "category_id": 1, "description": "desc"},
+    )
+    resp = client.post(
+        "/api/questions/",
+        json={
+            "id": 1,
+            "category_id": 1,
+            "subcategory_id": 1,
+            "description": "Q1",
+            "details": "more info",
+        },
+    )
     assert resp.status_code == 200
-    resp = client.get('/api/questions/')
+    resp = client.get("/api/questions/")
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 1
 
 
 def test_score_processes(client):
-    client.post('/api/categories/', json={'id': 1, 'name': 'Cat'})
-    client.post('/api/processes/', json={'name': 'P1', 'category_id': 1})
-    client.post('/api/processes/', json={'name': 'P2', 'category_id': 1})
-    client.post('/api/processes/', json={'name': 'P3', 'category_id': 1})
+    client.post("/api/categories/", json={"id": 1, "name": "Cat"})
+    client.post("/api/processes/", json={"name": "P1", "category_id": 1})
+    client.post("/api/processes/", json={"name": "P2", "category_id": 1})
+    client.post("/api/processes/", json={"name": "P3", "category_id": 1})
 
     payload = [
-        {'process_id': 1, 'score': 1},
-        {'process_id': 2, 'score': None},
-        {'process_id': 3, 'score': 5}
+        {"process_id": 1, "score": 1},
+        {"process_id": 2, "score": None},
+        {"process_id": 3, "score": 5},
     ]
-    resp = client.post('/api/scoring/', json=payload)
+    resp = client.post("/api/scoring/", json=payload)
     assert resp.status_code == 200
     data = resp.json()
-    assert data['by_process'] == [1, 5]
-    assert data['overall'] == pytest.approx(3)
+    assert data["by_process"] == [1, 5]
+    assert data["overall"] == pytest.approx(3)
 
 
 def test_list_processes_by_category(client):
-    client.post('/api/categories/', json={'id': 1, 'name': 'Cat1'})
-    client.post('/api/categories/', json={'id': 2, 'name': 'Cat2'})
-    client.post('/api/processes/', json={'name': 'P1', 'category_id': 1})
-    client.post('/api/processes/', json={'name': 'P2', 'category_id': 2})
+    client.post("/api/categories/", json={"id": 1, "name": "Cat1"})
+    client.post("/api/categories/", json={"id": 2, "name": "Cat2"})
+    client.post("/api/processes/", json={"name": "P1", "category_id": 1})
+    client.post("/api/processes/", json={"name": "P2", "category_id": 2})
 
-    resp = client.get('/api/processes/', params={'category_id': '1'})
+    resp = client.get("/api/processes/", params={"category_id": "1"})
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 1
-    assert data[0]['category_id'] == 1
+    assert data[0]["category_id"] == 1
 
 
 def test_list_questions_by_category(client):
-    client.post('/api/categories/', json={'id': 1, 'name': 'Cat1'})
-    client.post('/api/categories/', json={'id': 2, 'name': 'Cat2'})
-    client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub1', 'category_id': 1})
-    client.post('/api/subcategories/', json={'id': 2, 'name': 'Sub2', 'category_id': 2})
-    client.post('/api/questions/', json={'id': 1, 'category_id': 1, 'subcategory_id': 1, 'description': 'Q1'})
-    client.post('/api/questions/', json={'id': 2, 'category_id': 1, 'subcategory_id': 1, 'description': 'Q2'})
-    client.post('/api/questions/', json={'id': 3, 'category_id': 2, 'subcategory_id': 2, 'description': 'Q3'})
+    client.post("/api/categories/", json={"id": 1, "name": "Cat1"})
+    client.post("/api/categories/", json={"id": 2, "name": "Cat2"})
+    client.post(
+        "/api/subcategories/",
+        json={"id": 1, "name": "Sub1", "category_id": 1, "description": "d1"},
+    )
+    client.post(
+        "/api/subcategories/",
+        json={"id": 2, "name": "Sub2", "category_id": 2, "description": "d2"},
+    )
+    client.post(
+        "/api/questions/",
+        json={
+            "id": 1,
+            "category_id": 1,
+            "subcategory_id": 1,
+            "description": "Q1",
+            "details": "x",
+        },
+    )
+    client.post(
+        "/api/questions/",
+        json={
+            "id": 2,
+            "category_id": 1,
+            "subcategory_id": 1,
+            "description": "Q2",
+            "details": "y",
+        },
+    )
+    client.post(
+        "/api/questions/",
+        json={
+            "id": 3,
+            "category_id": 2,
+            "subcategory_id": 2,
+            "description": "Q3",
+            "details": "z",
+        },
+    )
 
-    resp = client.get('/api/questions/', params={'category_id': '1'})
+    resp = client.get("/api/questions/", params={"category_id": "1"})
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 2
-    assert all(q['category_id'] == 1 for q in data)
+    assert all(q["category_id"] == 1 for q in data)
+
+
+def test_duplicate_ids_allowed(client):
+    """Questions and subcategories can reuse local IDs in different parents."""
+    client.post("/api/categories/", json={"id": 1, "name": "Cat1"})
+    client.post("/api/categories/", json={"id": 2, "name": "Cat2"})
+
+    # same subcategory id in different categories
+    client.post(
+        "/api/subcategories/",
+        json={"id": 1, "name": "Sub", "category_id": 1, "description": "d"},
+    )
+    resp = client.post(
+        "/api/subcategories/",
+        json={"id": 1, "name": "Sub", "category_id": 2, "description": "d"},
+    )
+    assert resp.status_code == 200
+
+    # same question id in different subcategories
+    client.post(
+        "/api/questions/",
+        json={
+            "id": 1,
+            "category_id": 1,
+            "subcategory_id": 1,
+            "description": "Q1",
+            "details": "d1",
+        },
+    )
+    resp = client.post(
+        "/api/questions/",
+        json={
+            "id": 1,
+            "category_id": 2,
+            "subcategory_id": 1,
+            "description": "Q2",
+            "details": "d2",
+        },
+    )
+    assert resp.status_code == 200
+
+    resp = client.get("/api/questions/")
+    assert len(resp.json()) == 2


### PR DESCRIPTION
## Summary
- use composite keys so subcategory numbering resets per category
- same for questions within subcategories
- update initial data loader and YAML fixtures
- add regression test allowing duplicate local IDs
- add descriptions for subcategories and questions
- group questions by subcategory in the form
- new endpoint and API helper for subcategories
- document new frontend guidelines

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68543cc4b4788331b69e3f39f7c733b8