### PR TITLE
Add category-based question pages with progress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,2 +1,7 @@
 All frontend components use React Bootstrap for styling.
 Import `'bootstrap/dist/css/bootstrap.min.css'` in `frontend/src/main.tsx` and use `react-bootstrap` components such as `Form`, `Button`, and `Container` instead of raw HTML tags wherever possible.
+
+Forms displaying questions should organise them by category. Only one category is shown per page and a progress bar indicates answered categories versus total.
+Within each category, questions are grouped by subcategory. Subcategory name and description appear before its questions and should visually separate groups.
+Every question consists of main text and an additional description displayed in smaller type.
+Ratings are provided with radio buttons on a 1–5 scale plus a colour coded "N/A" option placed to the right of the scale.

--- a/app/api/subcategories.py
+++ b/app/api/subcategories.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
-from typing import List
+from typing import List, Optional
 
 from app.core.db import get_db
 from app.models.models import Subcategory
@@ -19,5 +19,9 @@ def create_subcategory(subcat: SubcategoryCreate, db: Session = Depends(get_db))
 
 
 @router.get("/", response_model=List[SubcategoryRead])
-def list_subcategories(db: Session = Depends(get_db)):
-    return db.query(Subcategory).all()
+def list_subcategories(category_id: Optional[str] = None, db: Session = Depends(get_db)):
+    query = db.query(Subcategory)
+    if category_id:
+        ids = [int(i) for i in category_id.split(',') if i]
+        query = query.filter(Subcategory.category_id.in_(ids))
+    return query.all()

--- a/app/initial_data.yml
+++ b/app/initial_data.yml
@@ -6,16 +6,20 @@ categories:
 subcategories:
   - id: 10
     name: Security
+    description: Questions related to security practices
     category_id: 10
   - id: 20
     name: Recruitment
+    description: Hiring and onboarding topics
     category_id: 20
 questions:
   - id: 10
     category_id: 10
     subcategory_id: 10
     description: Do you use two-factor authentication?
+    detail: Additional info about MFA usage
   - id: 20
     category_id: 20
     subcategory_id: 20
     description: Do you have a hiring process?
+    detail: Outline of recruitment procedures

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -19,6 +19,7 @@ class Subcategory(Base):
     __tablename__ = 'subcategories'
     id = Column(Integer, primary_key=True, autoincrement=False)
     name = Column(String, nullable=False)
+    description = Column(String, default="", nullable=True)
     category_id = Column(Integer, ForeignKey('categories.id'), nullable=False)
 
 
@@ -28,3 +29,4 @@ class Question(Base):
     category_id = Column(Integer, ForeignKey('categories.id'), nullable=False)
     subcategory_id = Column(Integer, ForeignKey('subcategories.id'), nullable=False)
     description = Column(String, nullable=False)
+    detail = Column(String, default="", nullable=True)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -31,6 +31,7 @@ class CategoryRead(CategoryBase):
 class SubcategoryBase(BaseModel):
     id: int
     name: str
+    description: str | None = None
     category_id: int
 
 
@@ -48,6 +49,7 @@ class QuestionBase(BaseModel):
     category_id: int
     subcategory_id: int
     description: str
+    detail: str | None = None
 
 
 class QuestionCreate(QuestionBase):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,15 @@
 import { useState } from 'react'
-import GeneralForm from './components/GeneralForm'
+import CategoryQuestionsForm from './components/CategoryQuestionsForm'
 import CategoryForm from './components/CategoryForm'
 import ResultsView from './components/ResultsView'
-import { Question } from './types'
+import { Category } from './types'
 import { Container, Button } from 'react-bootstrap'
 
 export default function App() {
   const [step, setStep] = useState<'start' | 'categories' | 'questions' | 'results'>('start')
-  const [selectedCategories, setSelectedCategories] = useState<number[]>([])
-  const [questions, setQuestions] = useState<Question[]>([])
-  const [results, setResults] = useState<number[] | null>(null)
+  const [selectedCategories, setSelectedCategories] = useState<Category[]>([])
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [results, setResults] = useState<number[]>([])
 
   if (step === 'start') {
     return (
@@ -23,8 +23,10 @@ export default function App() {
     return (
       <Container className="mt-4">
         <CategoryForm
-          onSubmit={(ids) => {
-            setSelectedCategories(ids)
+          onSubmit={(cats) => {
+            setSelectedCategories(cats)
+            setCurrentIndex(0)
+            setResults([])
             setStep('questions')
           }}
         />
@@ -33,15 +35,20 @@ export default function App() {
   }
 
   if (step === 'questions') {
+    const category = selectedCategories[currentIndex]
     return (
       <Container className="mt-4">
-        <GeneralForm
-          categoryIds={selectedCategories}
-          questions={questions}
-          setQuestions={setQuestions}
-          onSubmit={(res) => {
-            setResults(res)
-            setStep('results')
+        <CategoryQuestionsForm
+          category={category}
+          index={currentIndex}
+          total={selectedCategories.length}
+          onSubmit={(vals) => {
+            setResults((prev) => [...prev, ...vals])
+            if (currentIndex + 1 < selectedCategories.length) {
+              setCurrentIndex(currentIndex + 1)
+            } else {
+              setStep('results')
+            }
           }}
         />
       </Container>

--- a/frontend/src/api/subcategories.ts
+++ b/frontend/src/api/subcategories.ts
@@ -1,0 +1,12 @@
+import axios from 'axios'
+import { Subcategory } from '../types'
+
+const api = axios.create({ baseURL: '/api' })
+
+export const getSubcategories = async (categories?: number[]): Promise<Subcategory[]> => {
+  const params = categories && categories.length ? { category_id: categories.join(',') } : {}
+  const res = await api.get<Subcategory[]>('/subcategories/', { params })
+  return res.data
+}
+
+export default api

--- a/frontend/src/components/CategoryForm.tsx
+++ b/frontend/src/components/CategoryForm.tsx
@@ -5,7 +5,7 @@ import { Category } from '../types'
 import { Form, Button } from 'react-bootstrap'
 
 interface Props {
-  onSubmit: (categoryIds: number[]) => void
+  onSubmit: (categories: Category[]) => void
 }
 
 export default function CategoryForm({ onSubmit }: Props) {
@@ -17,16 +17,16 @@ export default function CategoryForm({ onSubmit }: Props) {
   }, [])
 
   const submit = handleSubmit((data) => {
-    const ids: number[] = []
+    const result: Category[] = []
     categories.forEach((c) => {
       const applies = data[`applies_${c.id}`] === 'yes'
       const implemented = data[`impl_${c.id}`] === 'yes'
       const want = data[`want_${c.id}`] === 'yes'
       if (applies && (implemented || want)) {
-        ids.push(c.id)
+        result.push(c)
       }
     })
-    onSubmit(ids)
+    onSubmit(result)
   })
 
   return (

--- a/frontend/src/components/CategoryQuestionsForm.tsx
+++ b/frontend/src/components/CategoryQuestionsForm.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { getQuestions } from '../api/questions'
+import { getSubcategories } from '../api/subcategories'
+import { Question, Subcategory, Category } from '../types'
+import { Form, Button, ProgressBar } from 'react-bootstrap'
+
+interface Props {
+  category: Category
+  index: number
+  total: number
+  onSubmit: (values: number[]) => void
+}
+
+export default function CategoryQuestionsForm({ category, index, total, onSubmit }: Props) {
+  const { register, handleSubmit } = useForm<Record<string, string>>({})
+  const [questions, setQuestions] = useState<Question[]>([])
+  const [subcategories, setSubcategories] = useState<Subcategory[]>([])
+
+  useEffect(() => {
+    getQuestions([category.id]).then(setQuestions)
+    getSubcategories([category.id]).then(setSubcategories)
+  }, [category.id])
+
+  const submit = handleSubmit((data) => {
+    const values = Object.values(data).map((v) => (v === 'NA' ? 0 : Number(v)))
+    onSubmit(values)
+  })
+
+  return (
+    <Form onSubmit={submit}>
+      <h3>{category.name}</h3>
+      <ProgressBar now={((index + 1) / total) * 100} label={`${index + 1}/${total}`} className="mb-3" />
+      {subcategories.map((sub) => (
+        <div key={sub.id} className="mb-4">
+          <h5>{sub.name}</h5>
+          {sub.description && <p className="text-muted">{sub.description}</p>}
+          {questions.filter((q) => q.subcategory_id === sub.id).map((q) => (
+            <div key={q.id} className="mb-3">
+              <Form.Label>{q.description}</Form.Label>
+              {q.detail && <div className="text-muted mb-1" style={{ fontSize: 'smaller' }}>{q.detail}</div>}
+              <div className="d-flex align-items-center">
+                <div className="me-2">
+                  {[1,2,3,4,5].map((n) => (
+                    <Form.Check
+                      key={n}
+                      inline
+                      type="radio"
+                      id={`${q.id}_${n}`}
+                      label={String(n)}
+                      value={n}
+                      {...register(String(q.id))}
+                    />
+                  ))}
+                </div>
+                <Form.Check
+                  inline
+                  type="radio"
+                  id={`${q.id}_na`}
+                  label="N/A"
+                  value="NA"
+                  className="text-secondary"
+                  {...register(String(q.id))}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      ))}
+      <Button type="submit">{index + 1 === total ? 'Zakończ' : 'Dalej'}</Button>
+    </Form>
+  )
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -7,8 +7,16 @@ export interface Process {
 export interface Question {
   id: number
   description: string
+  detail?: string
   category_id: number
   subcategory_id: number
+}
+
+export interface Subcategory {
+  id: number
+  name: string
+  description?: string
+  category_id: number
 }
 
 export interface Category {

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -42,10 +42,10 @@ def test_score_ignores_missing_process(client):
 def test_list_questions_multiple_categories(client):
     client.post('/api/categories/', json={'id': 1, 'name': 'Cat1'})
     client.post('/api/categories/', json={'id': 2, 'name': 'Cat2'})
-    client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub1', 'category_id': 1})
-    client.post('/api/subcategories/', json={'id': 2, 'name': 'Sub2', 'category_id': 2})
-    client.post('/api/questions/', json={'id': 1, 'category_id': 1, 'subcategory_id': 1, 'description': 'Q1'})
-    client.post('/api/questions/', json={'id': 2, 'category_id': 2, 'subcategory_id': 2, 'description': 'Q2'})
+    client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub1', 'description': 'd1', 'category_id': 1})
+    client.post('/api/subcategories/', json={'id': 2, 'name': 'Sub2', 'description': 'd2', 'category_id': 2})
+    client.post('/api/questions/', json={'id': 1, 'category_id': 1, 'subcategory_id': 1, 'description': 'Q1', 'detail': 'd1'})
+    client.post('/api/questions/', json={'id': 2, 'category_id': 2, 'subcategory_id': 2, 'description': 'Q2', 'detail': 'd2'})
     resp = client.get('/api/questions/', params={'category_id': '1,2'})
     assert resp.status_code == 200
     data = resp.json()
@@ -56,8 +56,8 @@ def test_load_initial_data(tmp_path):
     os.environ['SKIP_INIT_DATA'] = ''
     data = {
         'categories': [{'id': 1, 'name': 'Cat'}],
-        'subcategories': [{'id': 1, 'name': 'Sub', 'category_id': 1}],
-        'questions': [{'id': 1, 'category_id': 1, 'subcategory_id': 1, 'description': 'Q'}]
+        'subcategories': [{'id': 1, 'name': 'Sub', 'description': 'd', 'category_id': 1}],
+        'questions': [{'id': 1, 'category_id': 1, 'subcategory_id': 1, 'description': 'Q', 'detail': 'info'}]
     }
     path = tmp_path / 'data.yml'
     path.write_text(yaml.safe_dump(data))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -36,7 +36,7 @@ def test_create_and_list_categories(client):
 
 def test_create_subcategory(client):
     client.post('/api/categories/', json={'id': 1, 'name': 'Cat'})
-    resp = client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub', 'category_id': 1})
+    resp = client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub', 'description': 'Desc', 'category_id': 1})
     assert resp.status_code == 200
     resp = client.get('/api/subcategories/')
     assert resp.status_code == 200
@@ -47,12 +47,13 @@ def test_create_subcategory(client):
 
 def test_create_question(client):
     client.post('/api/categories/', json={'id': 1, 'name': 'Cat'})
-    client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub', 'category_id': 1})
+    client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub', 'description': 'Desc', 'category_id': 1})
     resp = client.post('/api/questions/', json={
         'id': 1,
         'category_id': 1,
         'subcategory_id': 1,
-        'description': 'Q1'
+        'description': 'Q1',
+        'detail': 'd'
     })
     assert resp.status_code == 200
     resp = client.get('/api/questions/')
@@ -95,8 +96,8 @@ def test_list_processes_by_category(client):
 def test_list_questions_by_category(client):
     client.post('/api/categories/', json={'id': 1, 'name': 'Cat1'})
     client.post('/api/categories/', json={'id': 2, 'name': 'Cat2'})
-    client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub1', 'category_id': 1})
-    client.post('/api/subcategories/', json={'id': 2, 'name': 'Sub2', 'category_id': 2})
+    client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub1', 'description': 'd1', 'category_id': 1})
+    client.post('/api/subcategories/', json={'id': 2, 'name': 'Sub2', 'description': 'd2', 'category_id': 2})
     client.post('/api/questions/', json={'id': 1, 'category_id': 1, 'subcategory_id': 1, 'description': 'Q1'})
     client.post('/api/questions/', json={'id': 2, 'category_id': 1, 'subcategory_id': 1, 'description': 'Q2'})
     client.post('/api/questions/', json={'id': 3, 'category_id': 2, 'subcategory_id': 2, 'description': 'Q3'})
@@ -106,3 +107,16 @@ def test_list_questions_by_category(client):
     data = resp.json()
     assert len(data) == 2
     assert all(q['category_id'] == 1 for q in data)
+
+
+def test_list_subcategories_by_category(client):
+    client.post('/api/categories/', json={'id': 1, 'name': 'Cat1'})
+    client.post('/api/categories/', json={'id': 2, 'name': 'Cat2'})
+    client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub1', 'description': 'd1', 'category_id': 1})
+    client.post('/api/subcategories/', json={'id': 2, 'name': 'Sub2', 'description': 'd2', 'category_id': 2})
+
+    resp = client.get('/api/subcategories/', params={'category_id': '1'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]['category_id'] == 1


### PR DESCRIPTION
## Summary
- group questions by category and show single-category pages
- show progress bar for answered categories
- group questions by subcategory with descriptions
- enhance rating scale with radio buttons including colour coded N/A
- expose subcategory filter API
- support descriptions for subcategories and details for questions
- update initial data and tests
- document form design rules in AGENTS.md

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685447f4795883319374a78b6d03cb84