### PR TITLE
Fix duplicate categories in CategoryForm

### DIFF
--- a/frontend/src/components/CategoryForm.tsx
+++ b/frontend/src/components/CategoryForm.tsx
@@ -13,7 +13,12 @@ export default function CategoryForm({ onSubmit }: Props) {
   const [categories, setCategories] = React.useState<Category[]>([])
 
   useEffect(() => {
-    axios.get<Category[]>('/api/categories/').then(res => setCategories(res.data))
+    axios.get<Category[]>('/api/categories/').then(res => {
+      const unique = res.data.filter(
+        (c, idx, arr) => arr.findIndex((x) => x.id === c.id) === idx,
+      )
+      setCategories(unique)
+    })
   }, [])
 
   const submit = handleSubmit((data) => {


### PR DESCRIPTION
## Summary
- deduplicate categories after fetching them

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544c0123a083318510e45f9cb46856