### PR TITLE
Fix duplicate categories in backend

### DIFF
--- a/app/api/categories.py
+++ b/app/api/categories.py
@@ -20,4 +20,11 @@ def create_category(category: CategoryCreate, db: Session = Depends(get_db)):
 
 @router.get("/", response_model=List[CategoryRead])
 def list_categories(db: Session = Depends(get_db)):
-    return db.query(Category).all()
+    # avoid returning duplicate category names
+    seen = set()
+    result = []
+    for cat in db.query(Category).order_by(Category.id).all():
+        if cat.name not in seen:
+            seen.add(cat.name)
+            result.append(cat)
+    return result

--- a/frontend/src/components/CategoryForm.tsx
+++ b/frontend/src/components/CategoryForm.tsx
@@ -13,7 +13,12 @@ export default function CategoryForm({ onSubmit }: Props) {
   const [categories, setCategories] = React.useState<Category[]>([])
 
   useEffect(() => {
-    axios.get<Category[]>('/api/categories/').then(res => setCategories(res.data))
+    axios.get<Category[]>('/api/categories/').then(res => {
+      const unique = res.data.filter(
+        (c, idx, arr) => arr.findIndex((x) => x.id === c.id) === idx,
+      )
+      setCategories(unique)
+    })
   }, [])
 
   const submit = handleSubmit((data) => {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,6 +34,15 @@ def test_create_and_list_categories(client):
     assert resp.status_code == 200
     assert len(resp.json()) == 1
 
+def test_category_deduplication(client):
+    client.post('/api/categories/', json={'id': 1, 'name': 'Cat'})
+    client.post('/api/categories/', json={'id': 2, 'name': 'Cat'})
+    resp = client.get('/api/categories/')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]['name'] == 'Cat'
+
 def test_create_subcategory(client):
     client.post('/api/categories/', json={'id': 1, 'name': 'Cat'})
     resp = client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub', 'description': 'Desc', 'category_id': 1})


### PR DESCRIPTION
## Summary
- ensure `/api/categories` filters repeated names
- test deduplicated categories

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68544c0123a083318510e45f9cb46856