### PR TITLE
Group duplicate category names on frontend

### DIFF
--- a/app/api/categories.py
+++ b/app/api/categories.py
@@ -20,4 +20,4 @@ def create_category(category: CategoryCreate, db: Session = Depends(get_db)):
 
 @router.get("/", response_model=List[CategoryRead])
 def list_categories(db: Session = Depends(get_db)):
-    return db.query(Category).all()
+    return db.query(Category).order_by(Category.id).all()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,12 +2,12 @@ import { useState } from 'react'
 import CategoryQuestionsForm from './components/CategoryQuestionsForm'
 import CategoryForm from './components/CategoryForm'
 import ResultsView from './components/ResultsView'
-import { Category } from './types'
+import { CategoryGroup } from './types'
 import { Container, Button } from 'react-bootstrap'
 
 export default function App() {
   const [step, setStep] = useState<'start' | 'categories' | 'questions' | 'results'>('start')
-  const [selectedCategories, setSelectedCategories] = useState<Category[]>([])
+  const [selectedCategories, setSelectedCategories] = useState<CategoryGroup[]>([])
   const [currentIndex, setCurrentIndex] = useState(0)
   const [results, setResults] = useState<number[]>([])
 

--- a/frontend/src/components/CategoryForm.tsx
+++ b/frontend/src/components/CategoryForm.tsx
@@ -1,23 +1,34 @@
 import React, { useEffect } from 'react'
 import { useForm, Controller } from 'react-hook-form'
 import axios from 'axios'
-import { Category } from '../types'
+import { CategoryGroup, Category } from '../types'
 import { Form, Button } from 'react-bootstrap'
 
 interface Props {
-  onSubmit: (categories: Category[]) => void
+  onSubmit: (categories: CategoryGroup[]) => void
 }
 
 export default function CategoryForm({ onSubmit }: Props) {
   const { control, handleSubmit, watch } = useForm<Record<string, string>>({})
-  const [categories, setCategories] = React.useState<Category[]>([])
+  const [categories, setCategories] = React.useState<CategoryGroup[]>([])
 
   useEffect(() => {
-    axios.get<Category[]>('/api/categories/').then(res => setCategories(res.data))
+    axios.get<Category[]>('/api/categories/').then(res => {
+      const map = new Map<string, CategoryGroup>()
+      res.data.forEach((c) => {
+        const existing = map.get(c.name)
+        if (existing) {
+          existing.ids.push(c.id)
+        } else {
+          map.set(c.name, { ...c, ids: [c.id] })
+        }
+      })
+      setCategories(Array.from(map.values()))
+    })
   }, [])
 
   const submit = handleSubmit((data) => {
-    const result: Category[] = []
+    const result: CategoryGroup[] = []
     categories.forEach((c) => {
       const applies = data[`applies_${c.id}`] === 'yes'
       const implemented = data[`impl_${c.id}`] === 'yes'

--- a/frontend/src/components/CategoryQuestionsForm.tsx
+++ b/frontend/src/components/CategoryQuestionsForm.tsx
@@ -2,11 +2,11 @@ import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { getQuestions } from '../api/questions'
 import { getSubcategories } from '../api/subcategories'
-import { Question, Subcategory, Category } from '../types'
+import { Question, Subcategory, CategoryGroup } from '../types'
 import { Form, Button, ProgressBar } from 'react-bootstrap'
 
 interface Props {
-  category: Category
+  category: CategoryGroup
   index: number
   total: number
   onSubmit: (values: number[]) => void
@@ -18,9 +18,9 @@ export default function CategoryQuestionsForm({ category, index, total, onSubmit
   const [subcategories, setSubcategories] = useState<Subcategory[]>([])
 
   useEffect(() => {
-    getQuestions([category.id]).then(setQuestions)
-    getSubcategories([category.id]).then(setSubcategories)
-  }, [category.id])
+    getQuestions(category.ids).then(setQuestions)
+    getSubcategories(category.ids).then(setSubcategories)
+  }, [category.ids])
 
   const submit = handleSubmit((data) => {
     const values = Object.values(data).map((v) => (v === 'NA' ? 0 : Number(v)))

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -23,3 +23,7 @@ export interface Category {
   id: number
   name: string
 }
+
+export interface CategoryGroup extends Category {
+  ids: number[]
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,6 +34,14 @@ def test_create_and_list_categories(client):
     assert resp.status_code == 200
     assert len(resp.json()) == 1
 
+def test_category_deduplication(client):
+    client.post('/api/categories/', json={'id': 1, 'name': 'Cat'})
+    client.post('/api/categories/', json={'id': 2, 'name': 'Cat'})
+    resp = client.get('/api/categories/')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+
 def test_create_subcategory(client):
     client.post('/api/categories/', json={'id': 1, 'name': 'Cat'})
     resp = client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub', 'description': 'Desc', 'category_id': 1})


### PR DESCRIPTION
## Summary
- revert category endpoint to return all rows
- group duplicate names when loading categories
- pass all category ids to question fetching
- update API test expectations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68544c0123a083318510e45f9cb46856