### PR TITLE
Fix missing descriptions in questionnaire form

### DIFF
--- a/frontend/src/components/CategoryQuestionsForm.tsx
+++ b/frontend/src/components/CategoryQuestionsForm.tsx
@@ -34,11 +34,19 @@ export default function CategoryQuestionsForm({ category, index, total, onSubmit
       {subcategories.map((sub) => (
         <div key={sub.id} className="mb-4">
           <h5>{sub.name}</h5>
-          {sub.description && <p className="text-muted">{sub.description}</p>}
+          {sub.description && (
+            <Form.Text className="text-muted d-block mb-2">
+              {sub.description}
+            </Form.Text>
+          )}
           {questions.filter((q) => q.subcategory_id === sub.id).map((q) => (
             <div key={q.id} className="mb-3">
               <Form.Label>{q.description}</Form.Label>
-              {q.detail && <div className="text-muted mb-1" style={{ fontSize: 'smaller' }}>{q.detail}</div>}
+              {q.detail && (
+                <Form.Text className="text-muted mb-1" style={{ fontSize: 'smaller' }}>
+                  {q.detail}
+                </Form.Text>
+              )}
               <div className="d-flex align-items-center">
                 <div className="me-2">
                   {[1,2,3,4,5].map((n) => (


### PR DESCRIPTION
## Summary
- ensure subcategory and question descriptions render consistently using `Form.Text`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685456ef1b388331b206633256cbf0f6