### PR TITLE
Fix missing descriptions in questionnaire form

### DIFF
--- a/frontend/src/components/CategoryQuestionsForm.tsx
+++ b/frontend/src/components/CategoryQuestionsForm.tsx
@@ -33,12 +33,24 @@ export default function CategoryQuestionsForm({ category, index, total, onSubmit
       <ProgressBar now={((index + 1) / total) * 100} label={`${index + 1}/${total}`} className="mb-3" />
       {subcategories.map((sub) => (
         <div key={sub.id} className="mb-4">
-          <h5>{sub.name}</h5>
-          {sub.description && <p className="text-muted">{sub.description}</p>}
+          <Form.Group>
+            <Form.Label as="h5" className="mb-0">
+              {sub.name}
+            </Form.Label>
+            {sub.description && (
+              <Form.Text className="text-muted d-block mb-2">
+                {sub.description}
+              </Form.Text>
+            )}
+          </Form.Group>
           {questions.filter((q) => q.subcategory_id === sub.id).map((q) => (
-            <div key={q.id} className="mb-3">
+            <Form.Group key={q.id} className="mb-3">
               <Form.Label>{q.description}</Form.Label>
-              {q.detail && <div className="text-muted mb-1" style={{ fontSize: 'smaller' }}>{q.detail}</div>}
+              {q.detail && (
+                <Form.Text className="text-muted d-block mb-1" style={{ fontSize: 'smaller' }}>
+                  {q.detail}
+                </Form.Text>
+              )}
               <div className="d-flex align-items-center">
                 <div className="me-2">
                   {[1,2,3,4,5].map((n) => (
@@ -63,7 +75,7 @@ export default function CategoryQuestionsForm({ category, index, total, onSubmit
                   {...register(String(q.id))}
                 />
               </div>
-            </div>
+            </Form.Group>
           ))}
         </div>
       ))}


### PR DESCRIPTION
## Summary
- show subcategory name as Form.Label heading with description below
- wrap each question in a Form.Group and display details on a separate line

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685456ef1b388331b206633256cbf0f6