### PR TITLE
Add basic frontend test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 .test.db
 test.db
 .pytest_cache/
+frontend/node_modules/
+frontend/package-lock.json

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,23 +4,29 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "axios": "^1.4.0",
+    "bootstrap": "^5.3.2",
     "react": "^18.2.0",
+    "react-bootstrap": "^2.9.2",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.45.0",
-    "recharts": "^2.6.2",
-    "react-bootstrap": "^2.9.2",
-    "bootstrap": "^5.3.2"
+    "recharts": "^2.6.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/lodash": "^4.17.18",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^4.0.0",
+    "jsdom": "^26.1.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.9"
+    "vite": "^4.3.9",
+    "vitest": "^3.2.4"
   }
 }

--- a/frontend/src/components/__tests__/CategoryQuestionsForm.test.tsx
+++ b/frontend/src/components/__tests__/CategoryQuestionsForm.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { vi, describe, it, expect } from 'vitest'
+import CategoryQuestionsForm from '../CategoryQuestionsForm'
+import { CategoryGroup } from '../../types'
+
+vi.mock('../../api/questions', () => ({
+  getQuestions: vi.fn(() => Promise.resolve([
+    { id: 1, description: 'Q1', detail: 'qd1', category_id: 1, subcategory_id: 10 },
+    { id: 2, description: 'Q2', detail: 'qd2', category_id: 1, subcategory_id: 20 },
+  ]))
+}))
+
+vi.mock('../../api/subcategories', () => ({
+  getSubcategories: vi.fn(() => Promise.resolve([
+    { id: 10, name: 'Sub1', description: 'subdesc1', category_id: 1 },
+    { id: 20, name: 'Sub2', description: 'subdesc2', category_id: 1 },
+  ]))
+}))
+
+describe('CategoryQuestionsForm', () => {
+  const category: CategoryGroup = { id: 1, name: 'Cat', ids: [1] }
+
+  it('loads and displays subcategory and question descriptions', async () => {
+    render(<CategoryQuestionsForm category={category} index={0} total={1} onSubmit={() => {}} />)
+
+    // subcategory descriptions
+    expect(await screen.findByText('subdesc1')).toBeInTheDocument()
+    expect(await screen.findByText('subdesc2')).toBeInTheDocument()
+
+    // question details
+    expect(await screen.findByText('qd1')).toBeInTheDocument()
+    expect(await screen.findByText('qd2')).toBeInTheDocument()
+  })
+})

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.ts'
+  }
+})

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'


### PR DESCRIPTION
## Summary
- ignore frontend node modules and lock file
- setup Vitest with React Testing Library
- add a test verifying that question and subcategory descriptions display properly

## Testing
- `npx vitest run`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68545bd530908331a48868dc3ab0819a