### PR TITLE
Implement composite identifiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,9 @@ Forms displaying questions should organise them by category. Only one category i
 Within each category, questions are grouped by subcategory. Subcategory name and description appear before its questions and should visually separate groups.
 Every question consists of main text and an additional description displayed in smaller type.
 Ratings are provided with radio buttons on a 1–5 scale plus a colour coded "N/A" option placed to the right of the scale.
+
+IDs for questions are unique only in combination with their category and subcategory. Numbering of question IDs restarts within each subcategory, and numbering of subcategory IDs restarts within each category.
+# Lessons from composite ID implementation
+- Define composite primary keys for `subcategories` (category_id + id) and `questions` (category_id + subcategory_id + id).
+- Lookup and update records using the full composite key to prevent duplicate key errors.
+- Data seeding starts numbering subcategories at 1 for each category and questions at 1 for each subcategory.

--- a/alembic/versions/0004_composite_ids.py
+++ b/alembic/versions/0004_composite_ids.py
@@ -1,0 +1,48 @@
+"""use composite IDs for subcategories and questions
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2025-06-21 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.drop_table('questions')
+    op.drop_table('subcategories')
+    op.create_table(
+        'subcategories',
+        sa.Column('category_id', sa.Integer, sa.ForeignKey('categories.id'), primary_key=True),
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=False),
+        sa.Column('name', sa.String, nullable=False),
+        sa.Column('description', sa.String, nullable=True, server_default='')
+    )
+    op.create_table(
+        'questions',
+        sa.Column('category_id', sa.Integer, primary_key=True),
+        sa.Column('subcategory_id', sa.Integer, primary_key=True),
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=False),
+        sa.Column('description', sa.String, nullable=False),
+        sa.Column('detail', sa.String, nullable=True, server_default=''),
+        sa.ForeignKeyConstraint(['category_id'], ['categories.id']),
+        sa.ForeignKeyConstraint(['category_id', 'subcategory_id'], ['subcategories.category_id', 'subcategories.id'])
+    )
+
+def downgrade():
+    op.drop_table('questions')
+    op.drop_table('subcategories')
+    op.create_table(
+        'subcategories',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=False),
+        sa.Column('name', sa.String, nullable=False),
+        sa.Column('category_id', sa.Integer, sa.ForeignKey('categories.id'), nullable=False),
+        sa.Column('description', sa.String, nullable=True, server_default='')
+    )
+    op.create_table(
+        'questions',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=False),
+        sa.Column('category_id', sa.Integer, sa.ForeignKey('categories.id'), nullable=False),
+        sa.Column('subcategory_id', sa.Integer, sa.ForeignKey('subcategories.id'), nullable=False),
+        sa.Column('description', sa.String, nullable=False),
+        sa.Column('detail', sa.String, nullable=True, server_default='')
+    )

--- a/app/data_loader.py
+++ b/app/data_loader.py
@@ -8,9 +8,17 @@ from app.core.db import SessionLocal, engine
 from app.models.models import Base, Category, Subcategory, Question
 
 
+def _get_pk(model, item):
+    if model is Subcategory:
+        return (item['category_id'], item['id'])
+    if model is Question:
+        return (item['category_id'], item['subcategory_id'], item['id'])
+    return item['id']
+
+
 def _load_items(session, model, items: List[Dict[str, Any]]):
     for item in items:
-        obj = session.get(model, item['id'])
+        obj = session.get(model, _get_pk(model, item))
         if obj is None:
             session.add(model(**item))
         else:

--- a/app/initial_data.yml
+++ b/app/initial_data.yml
@@ -6,50 +6,50 @@ categories:
   - id: 30
     name: Finance
 subcategories:
-  - id: 10
+  - id: 1
     name: Security
     description: Questions related to security practices
     category_id: 10
-  - id: 40
+  - id: 2
     name: Infrastructure
     description: Servers and network operations
     category_id: 10
-  - id: 20
+  - id: 1
     name: Recruitment
     description: Hiring and onboarding topics
     category_id: 20
-  - id: 30
+  - id: 1
     name: Budgeting
     description: Financial planning and cost control
     category_id: 30
 questions:
-  - id: 10
+  - id: 1
     category_id: 10
-    subcategory_id: 10
+    subcategory_id: 1
     description: Do you use two-factor authentication?
     detail: Additional info about MFA usage
-  - id: 11
+  - id: 2
     category_id: 10
-    subcategory_id: 10
+    subcategory_id: 1
     description: Do you maintain secure coding standards?
     detail: Guidelines for secure development
-  - id: 40
+  - id: 1
     category_id: 10
-    subcategory_id: 40
+    subcategory_id: 2
     description: Are servers regularly updated?
     detail: Patch management processes
-  - id: 41
+  - id: 2
     category_id: 10
-    subcategory_id: 40
+    subcategory_id: 2
     description: Do you monitor network performance?
     detail: Tools used for monitoring
-  - id: 20
+  - id: 1
     category_id: 20
-    subcategory_id: 20
+    subcategory_id: 1
     description: Do you have a hiring process?
     detail: Outline of recruitment procedures
-  - id: 30
+  - id: 1
     category_id: 30
-    subcategory_id: 30
+    subcategory_id: 1
     description: Do you track departmental budgets?
     detail: Methods for monitoring budget spending

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, Integer, String, ForeignKey, ForeignKeyConstraint
 from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()
@@ -17,16 +17,20 @@ class Process(Base):
 
 class Subcategory(Base):
     __tablename__ = 'subcategories'
+    category_id = Column(Integer, ForeignKey('categories.id'), primary_key=True)
     id = Column(Integer, primary_key=True, autoincrement=False)
     name = Column(String, nullable=False)
     description = Column(String, default="", nullable=True)
-    category_id = Column(Integer, ForeignKey('categories.id'), nullable=False)
 
 
 class Question(Base):
     __tablename__ = 'questions'
+    category_id = Column(Integer, primary_key=True)
+    subcategory_id = Column(Integer, primary_key=True)
     id = Column(Integer, primary_key=True, autoincrement=False)
-    category_id = Column(Integer, ForeignKey('categories.id'), nullable=False)
-    subcategory_id = Column(Integer, ForeignKey('subcategories.id'), nullable=False)
     description = Column(String, nullable=False)
     detail = Column(String, default="", nullable=True)
+    __table_args__ = (
+        ForeignKeyConstraint(['category_id'], ['categories.id']),
+        ForeignKeyConstraint(['category_id', 'subcategory_id'], ['subcategories.category_id', 'subcategories.id']),
+    )

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -43,14 +43,15 @@ def test_list_questions_multiple_categories(client):
     client.post('/api/categories/', json={'id': 1, 'name': 'Cat1'})
     client.post('/api/categories/', json={'id': 2, 'name': 'Cat2'})
     client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub1', 'description': 'd1', 'category_id': 1})
-    client.post('/api/subcategories/', json={'id': 2, 'name': 'Sub2', 'description': 'd2', 'category_id': 2})
+    client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub2', 'description': 'd2', 'category_id': 2})
     client.post('/api/questions/', json={'id': 1, 'category_id': 1, 'subcategory_id': 1, 'description': 'Q1', 'detail': 'd1'})
-    client.post('/api/questions/', json={'id': 2, 'category_id': 2, 'subcategory_id': 2, 'description': 'Q2', 'detail': 'd2'})
+    client.post('/api/questions/', json={'id': 1, 'category_id': 2, 'subcategory_id': 1, 'description': 'Q2', 'detail': 'd2'})
     resp = client.get('/api/questions/', params={'category_id': '1,2'})
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 2
-    assert {q['id'] for q in data} == {1, 2}
+    ids = {(q['category_id'], q['subcategory_id'], q['id']) for q in data}
+    assert ids == {(1, 1, 1), (2, 1, 1)}
 
 def test_load_initial_data(tmp_path):
     os.environ['SKIP_INIT_DATA'] = ''

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -105,10 +105,10 @@ def test_list_questions_by_category(client):
     client.post('/api/categories/', json={'id': 1, 'name': 'Cat1'})
     client.post('/api/categories/', json={'id': 2, 'name': 'Cat2'})
     client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub1', 'description': 'd1', 'category_id': 1})
-    client.post('/api/subcategories/', json={'id': 2, 'name': 'Sub2', 'description': 'd2', 'category_id': 2})
+    client.post('/api/subcategories/', json={'id': 1, 'name': 'Sub2', 'description': 'd2', 'category_id': 2})
     client.post('/api/questions/', json={'id': 1, 'category_id': 1, 'subcategory_id': 1, 'description': 'Q1'})
     client.post('/api/questions/', json={'id': 2, 'category_id': 1, 'subcategory_id': 1, 'description': 'Q2'})
-    client.post('/api/questions/', json={'id': 3, 'category_id': 2, 'subcategory_id': 2, 'description': 'Q3'})
+    client.post('/api/questions/', json={'id': 1, 'category_id': 2, 'subcategory_id': 1, 'description': 'Q3'})
 
     resp = client.get('/api/questions/', params={'category_id': '1'})
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- create migration to drop existing `subcategories` and `questions` tables and recreate them with composite primary keys
- subcategory IDs restart per category and question IDs restart per subcategory
- document lessons learned about composite keys in `AGENTS.md`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855634602ac8331bea16505d8ed00da