### PR TITLE
Add assessment storage and report

### DIFF
--- a/alembic/versions/0005_add_assessments.py
+++ b/alembic/versions/0005_add_assessments.py
@@ -1,0 +1,29 @@
+"""add assessments table
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2025-06-22 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0005'
+down_revision = '0004'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'assessments',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('employees_range', sa.String, nullable=False),
+        sa.Column('volunteers_range', sa.String, nullable=False),
+        sa.Column('results', sa.JSON, nullable=False),
+        sa.Column('created_at', sa.DateTime, nullable=False, server_default=sa.func.now())
+    )
+
+
+def downgrade():
+    op.drop_table('assessments')

--- a/app/api/assessments.py
+++ b/app/api/assessments.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.core.db import get_db
+from app.models.models import Assessment
+from app.schemas import AssessmentCreate, AssessmentRead
+
+router = APIRouter(prefix="/api/assessments", tags=["assessments"])
+
+@router.post("/", response_model=AssessmentRead)
+def create_assessment(assessment: AssessmentCreate, db: Session = Depends(get_db)):
+    db_obj = Assessment(**assessment.model_dump())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+@router.get("/", response_model=List[AssessmentRead])
+def list_assessments(db: Session = Depends(get_db)):
+    return db.query(Assessment).order_by(Assessment.id).all()

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from app.api.scoring import router as scoring_router
 from app.api.categories import router as categories_router
 from app.api.subcategories import router as subcategories_router
 from app.api.questions import router as questions_router
+from app.api.assessments import router as assessments_router
 
 app = FastAPI()
 
@@ -20,3 +21,4 @@ app.include_router(scoring_router)
 app.include_router(categories_router)
 app.include_router(subcategories_router)
 app.include_router(questions_router)
+app.include_router(assessments_router)

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Column, Integer, String, ForeignKey, ForeignKeyConstraint
+from sqlalchemy import Column, Integer, String, ForeignKey, ForeignKeyConstraint, JSON, DateTime
 from sqlalchemy.orm import declarative_base
+from datetime import datetime
 
 Base = declarative_base()
 
@@ -34,3 +35,12 @@ class Question(Base):
         ForeignKeyConstraint(['category_id'], ['categories.id']),
         ForeignKeyConstraint(['category_id', 'subcategory_id'], ['subcategories.category_id', 'subcategories.id']),
     )
+
+
+class Assessment(Base):
+    __tablename__ = 'assessments'
+    id = Column(Integer, primary_key=True, index=True)
+    employees_range = Column(String, nullable=False)
+    volunteers_range = Column(String, nullable=False)
+    results = Column(JSON, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,5 +1,6 @@
-from typing import Optional
+from typing import Optional, List
 from pydantic import BaseModel
+from datetime import datetime
 
 class ProcessBase(BaseModel):
     name: str
@@ -63,3 +64,21 @@ class QuestionRead(QuestionBase):
 class ScoreInput(BaseModel):
     process_id: int
     score: Optional[int] = None
+
+
+class AssessmentBase(BaseModel):
+    employees_range: str
+    volunteers_range: str
+    results: List[int]
+
+
+class AssessmentCreate(AssessmentBase):
+    pass
+
+
+class AssessmentRead(AssessmentBase):
+    id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,20 +1,31 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import CategoryQuestionsForm from './components/CategoryQuestionsForm'
 import CategoryForm from './components/CategoryForm'
 import ResultsView from './components/ResultsView'
+import MetadataForm from './components/MetadataForm'
+import ReportView from './components/ReportView'
+import { createAssessment } from './api/assessments'
 import { CategoryGroup } from './types'
 import { Container, Button } from 'react-bootstrap'
 
 export default function App() {
-  const [step, setStep] = useState<'start' | 'categories' | 'questions' | 'results'>('start')
+  const [step, setStep] = useState<'start' | 'categories' | 'questions' | 'results' | 'report'>('start')
   const [selectedCategories, setSelectedCategories] = useState<CategoryGroup[]>([])
   const [currentIndex, setCurrentIndex] = useState(0)
   const [results, setResults] = useState<number[]>([])
+  const [metadata, setMetadata] = useState<{ employees_range: string; volunteers_range: string } | null>(null)
+
+  useEffect(() => {
+    if (step === 'results' && metadata) {
+      createAssessment({ ...metadata, results }).catch(() => {})
+    }
+  }, [step])
 
   if (step === 'start') {
     return (
-      <Container className="text-center mt-5">
-        <Button onClick={() => setStep('categories')}>Start</Button>
+      <Container className="mt-4">
+        <MetadataForm onSubmit={(m) => { setMetadata(m); setStep('categories') }} />
+        <Button variant="link" className="mt-3" onClick={() => setStep('report')}>Raporty</Button>
       </Container>
     )
   }
@@ -55,9 +66,19 @@ export default function App() {
     )
   }
 
+  if (step === 'results') {
+    return (
+      <Container className="mt-4">
+        <ResultsView results={results || []} />
+        <Button className="mt-3" onClick={() => setStep('start')}>Strona główna</Button>
+      </Container>
+    )
+  }
+
   return (
     <Container className="mt-4">
-      <ResultsView results={results || []} />
+      <ReportView />
+      <Button className="mt-3" onClick={() => setStep('start')}>Powrót</Button>
     </Container>
   )
 }

--- a/frontend/src/api/assessments.ts
+++ b/frontend/src/api/assessments.ts
@@ -1,0 +1,16 @@
+import axios from 'axios'
+import { AssessmentCreate, Assessment } from '../types'
+
+const api = axios.create({ baseURL: '/api' })
+
+export const createAssessment = async (data: AssessmentCreate): Promise<Assessment> => {
+  const res = await api.post<Assessment>('/assessments/', data)
+  return res.data
+}
+
+export const listAssessments = async (): Promise<Assessment[]> => {
+  const res = await api.get<Assessment[]>('/assessments/')
+  return res.data
+}
+
+export default api

--- a/frontend/src/components/MetadataForm.tsx
+++ b/frontend/src/components/MetadataForm.tsx
@@ -1,0 +1,48 @@
+import { useForm, Controller } from 'react-hook-form'
+import { Form, Button } from 'react-bootstrap'
+
+interface Props {
+  onSubmit: (values: { employees_range: string; volunteers_range: string }) => void
+}
+
+export default function MetadataForm({ onSubmit }: Props) {
+  const { control, handleSubmit } = useForm({})
+  const submit = handleSubmit((data) => {
+    onSubmit(data as any)
+  })
+
+  const empOptions = ['0-10', '11-50', '51-250', '251+']
+  const volOptions = ['0', '1-9', '10-49', '50+']
+
+  return (
+    <Form onSubmit={submit} className="mt-4">
+      <Form.Group className="mb-3">
+        <Form.Label>Liczba pracowników</Form.Label>
+        <Controller
+          name="employees_range"
+          control={control}
+          defaultValue="0-10"
+          render={({ field }) => (
+            <Form.Select {...field}>
+              {empOptions.map(o => <option key={o} value={o}>{o}</option>)}
+            </Form.Select>
+          )}
+        />
+      </Form.Group>
+      <Form.Group className="mb-3">
+        <Form.Label>Liczba wolontariuszy</Form.Label>
+        <Controller
+          name="volunteers_range"
+          control={control}
+          defaultValue="0"
+          render={({ field }) => (
+            <Form.Select {...field}>
+              {volOptions.map(o => <option key={o} value={o}>{o}</option>)}
+            </Form.Select>
+          )}
+        />
+      </Form.Group>
+      <Button type="submit">Dalej</Button>
+    </Form>
+  )
+}

--- a/frontend/src/components/ReportView.tsx
+++ b/frontend/src/components/ReportView.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+import { Table } from 'react-bootstrap'
+import { listAssessments } from '../api/assessments'
+import { Assessment } from '../types'
+
+export default function ReportView() {
+  const [data, setData] = useState<Assessment[]>([])
+
+  useEffect(() => {
+    listAssessments().then(setData)
+  }, [])
+
+  return (
+    <Table striped bordered size="sm" className="w-auto">
+      <thead>
+        <tr><th>ID</th><th>Pracownicy</th><th>Wolontariusze</th><th>Wyniki</th></tr>
+      </thead>
+      <tbody>
+        {data.map(d => (
+          <tr key={d.id}>
+            <td>{d.id}</td>
+            <td>{d.employees_range}</td>
+            <td>{d.volunteers_range}</td>
+            <td>{d.results.join(', ')}</td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -27,3 +27,14 @@ export interface Category {
 export interface CategoryGroup extends Category {
   ids: number[]
 }
+
+export interface AssessmentCreate {
+  employees_range: string
+  volunteers_range: string
+  results: number[]
+}
+
+export interface Assessment extends AssessmentCreate {
+  id: number
+  created_at: string
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -128,3 +128,21 @@ def test_list_subcategories_by_category(client):
     data = resp.json()
     assert len(data) == 1
     assert data[0]['category_id'] == 1
+
+
+def test_create_and_list_assessments(client):
+    payload = {
+        'employees_range': '1-10',
+        'volunteers_range': '0-5',
+        'results': [1, 2, 3]
+    }
+    resp = client.post('/api/assessments/', json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['id'] == 1
+    assert data['employees_range'] == '1-10'
+    resp = client.get('/api/assessments/')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]['results'] == [1, 2, 3]


### PR DESCRIPTION
## Summary
- store scores together with org metrics in `assessments` table
- expose API for saving and listing assessments
- collect employee/volunteer ranges in new `MetadataForm`
- send results to backend and display saved data in `ReportView`
- test new API endpoint

## Testing
- `pip install -r requirements.txt`
- `npm install`
- `npx vitest run`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855751470e883318642fcf63c131326