### PR TITLE
Add detailed averages on results page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,19 +5,19 @@ import ResultsView from './components/ResultsView'
 import MetadataForm from './components/MetadataForm'
 import ReportView from './components/ReportView'
 import { createAssessment } from './api/assessments'
-import { CategoryGroup } from './types'
+import { CategoryGroup, Score } from './types'
 import { Container, Button } from 'react-bootstrap'
 
 export default function App() {
   const [step, setStep] = useState<'start' | 'categories' | 'questions' | 'results' | 'report'>('start')
   const [selectedCategories, setSelectedCategories] = useState<CategoryGroup[]>([])
   const [currentIndex, setCurrentIndex] = useState(0)
-  const [results, setResults] = useState<number[]>([])
+  const [results, setResults] = useState<Score[]>([])
   const [metadata, setMetadata] = useState<{ employees_range: string; volunteers_range: string } | null>(null)
 
   useEffect(() => {
     if (step === 'results' && metadata) {
-      createAssessment({ ...metadata, results }).catch(() => {})
+      createAssessment({ ...metadata, results: results.map(r => r.value) }).catch(() => {})
     }
   }, [step])
 
@@ -69,7 +69,7 @@ export default function App() {
   if (step === 'results') {
     return (
       <Container className="mt-4">
-        <ResultsView results={results || []} />
+        <ResultsView results={results || []} categories={selectedCategories} />
         <Button className="mt-3" onClick={() => setStep('start')}>Strona główna</Button>
       </Container>
     )

--- a/frontend/src/components/CategoryQuestionsForm.tsx
+++ b/frontend/src/components/CategoryQuestionsForm.tsx
@@ -2,14 +2,14 @@ import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { getQuestions } from '../api/questions'
 import { getSubcategories } from '../api/subcategories'
-import { Question, Subcategory, CategoryGroup } from '../types'
+import { Question, Subcategory, CategoryGroup, Score } from '../types'
 import { Form, Button, ProgressBar } from 'react-bootstrap'
 
 interface Props {
   category: CategoryGroup
   index: number
   total: number
-  onSubmit: (values: number[]) => void
+  onSubmit: (values: Score[]) => void
 }
 
 export default function CategoryQuestionsForm({ category, index, total, onSubmit }: Props) {
@@ -23,8 +23,12 @@ export default function CategoryQuestionsForm({ category, index, total, onSubmit
   }, [category.ids])
 
   const submit = handleSubmit((data) => {
-    const values = Object.values(data).map((v) => (v === 'NA' ? 0 : Number(v)))
-    onSubmit(values)
+    const scores: Score[] = questions.map((q) => {
+      const val = data[`${q.category_id}_${q.subcategory_id}_${q.id}`]
+      const num = val === 'NA' || val === undefined || val === '' ? 0 : Number(val)
+      return { question: q, value: num }
+    })
+    onSubmit(scores)
   })
 
   return (

--- a/frontend/src/components/ResultsView.tsx
+++ b/frontend/src/components/ResultsView.tsx
@@ -1,26 +1,46 @@
-import { BarChart, Bar, XAxis, YAxis } from 'recharts'
-import { Table } from 'react-bootstrap'
+import { Accordion, Table } from 'react-bootstrap'
+import { CategoryGroup, Score } from '../types'
 
 interface Props {
-  results: number[]
+  results: Score[]
+  categories: CategoryGroup[]
 }
 
-export default function ResultsView({ results }: Props) {
-  const data = results.map((r, i) => ({ name: `P${i+1}`, value: r }))
+export default function ResultsView({ results, categories }: Props) {
+  const valid = results.filter(r => r.value > 0)
+  const overall = valid.length ? valid.reduce((s, r) => s + r.value, 0) / valid.length : 0
+
+  const catData = categories.map((c) => {
+    const scores = results.filter(r => c.ids.includes(r.question.category_id))
+    const validScores = scores.filter(r => r.value > 0)
+    const avg = validScores.length ? validScores.reduce((s, r) => s + r.value, 0) / validScores.length : 0
+    return { category: c, avg, scores }
+  })
+
   return (
     <div>
-      <Table striped bordered size="sm" className="w-auto">
-        <tbody>
-          {data.map((d) => (
-            <tr key={d.name}><td>{d.name}</td><td>{d.value.toFixed(2)}</td></tr>
-          ))}
-        </tbody>
-      </Table>
-      <BarChart width={300} height={200} data={data}>
-        <XAxis dataKey="name" />
-        <YAxis />
-        <Bar dataKey="value" fill="#8884d8" />
-      </BarChart>
+      <h4>Średni wynik całości: {overall.toFixed(2)}</h4>
+      <Accordion className="mt-3">
+        {catData.map((c, idx) => (
+          <Accordion.Item eventKey={String(idx)} key={c.category.id}>
+            <Accordion.Header>
+              {c.category.name} – {c.avg.toFixed(2)}
+            </Accordion.Header>
+            <Accordion.Body>
+              <Table striped bordered size="sm" className="w-auto">
+                <tbody>
+                  {c.scores.map(s => (
+                    <tr key={`${s.question.category_id}_${s.question.subcategory_id}_${s.question.id}`}> 
+                      <td>{s.question.description}</td>
+                      <td>{s.value > 0 ? s.value : 'N/D'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            </Accordion.Body>
+          </Accordion.Item>
+        ))}
+      </Accordion>
     </div>
   )
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -28,6 +28,11 @@ export interface CategoryGroup extends Category {
   ids: number[]
 }
 
+export interface Score {
+  question: Question
+  value: number
+}
+
 export interface AssessmentCreate {
   employees_range: string
   volunteers_range: string


### PR DESCRIPTION
## Summary
- track question scores in `CategoryQuestionsForm`
- pass new score data through the app and save numeric values only
- display overall and per-category averages in `ResultsView`

## Testing
- `pytest -q`
- `npm exec vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_e_68557dc995c483318d76a2204a7c3228