### PR TITLE
Enhance results view behaviour

### DIFF
--- a/frontend/src/components/ResultsView.tsx
+++ b/frontend/src/components/ResultsView.tsx
@@ -17,22 +17,39 @@ export default function ResultsView({ results, categories }: Props) {
     return { category: c, avg, scores }
   })
 
+  const scoreClass = (value: number) => {
+    if (value >= 4) return 'text-success'
+    if (value >= 3) return 'text-warning'
+    if (value > 0) return 'text-danger'
+    return 'text-secondary'
+  }
+
   return (
     <div>
-      <h4>Średni wynik całości: {overall.toFixed(2)}</h4>
-      <Accordion className="mt-3">
+      <h4>
+        Średni wynik całości:{' '}
+        <span className={scoreClass(overall)}>{overall.toFixed(2)}/5.0</span>
+      </h4>
+      <Accordion className="mt-3" alwaysOpen>
         {catData.map((c, idx) => (
           <Accordion.Item eventKey={String(idx)} key={c.category.id}>
             <Accordion.Header>
-              {c.category.name} – {c.avg.toFixed(2)}
+              {c.category.name} –{' '}
+              <span className={scoreClass(c.avg)}>{c.avg.toFixed(2)}/5.0</span>
             </Accordion.Header>
             <Accordion.Body>
               <Table striped bordered size="sm" className="w-auto">
                 <tbody>
                   {c.scores.map(s => (
-                    <tr key={`${s.question.category_id}_${s.question.subcategory_id}_${s.question.id}`}> 
+                    <tr key={`${s.question.category_id}_${s.question.subcategory_id}_${s.question.id}`}>
                       <td>{s.question.description}</td>
-                      <td>{s.value > 0 ? s.value : 'N/D'}</td>
+                      <td>
+                        {s.value > 0 ? (
+                          <span className={scoreClass(s.value)}>{s.value}/5.0</span>
+                        ) : (
+                          <span className="text-secondary">N/D</span>
+                        )}
+                      </td>
                     </tr>
                   ))}
                 </tbody>

--- a/frontend/src/components/__tests__/ResultsView.test.tsx
+++ b/frontend/src/components/__tests__/ResultsView.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ResultsView from '../ResultsView'
+import { CategoryGroup, Score } from '../../types'
+
+const categories: CategoryGroup[] = [
+  { id: 1, name: 'Cat1', ids: [1] },
+  { id: 2, name: 'Cat2', ids: [2] }
+]
+
+const questions = [
+  { id: 1, description: 'Q1', category_id: 1, subcategory_id: 1 },
+  { id: 2, description: 'Q2', category_id: 2, subcategory_id: 1 }
+]
+
+const results: Score[] = [
+  { question: questions[0], value: 4 },
+  { question: questions[1], value: 3 }
+]
+
+describe('ResultsView', () => {
+  it('shows scores with /5.0 suffix', () => {
+    render(<ResultsView results={results} categories={[categories[0]]} />)
+    expect(screen.getByText('4/5.0')).toBeInTheDocument()
+  })
+
+  it('allows opening multiple categories', async () => {
+    render(<ResultsView results={results} categories={categories} />)
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /Cat1/ }))
+    await user.click(screen.getByRole('button', { name: /Cat2/ }))
+    expect(screen.getByText('Q1')).toBeVisible()
+    expect(screen.getByText('Q2')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
- allow multiple result categories to be expanded simultaneously
- show score suffix `/5.0` and add colour coding
- test updated results view behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685580a36d288331922401bbed3df9bb