### PR TITLE
Add customizable scale labels

### DIFF
--- a/alembic/versions/0006_add_scale_labels.py
+++ b/alembic/versions/0006_add_scale_labels.py
@@ -1,0 +1,24 @@
+"""add scale label fields to questions
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2025-06-23 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0006'
+down_revision = '0005'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('questions', sa.Column('scale_min_text', sa.String(), nullable=True, server_default=''))
+    op.add_column('questions', sa.Column('scale_max_text', sa.String(), nullable=True, server_default=''))
+
+
+def downgrade():
+    op.drop_column('questions', 'scale_max_text')
+    op.drop_column('questions', 'scale_min_text')

--- a/app/initial_data.yml
+++ b/app/initial_data.yml
@@ -28,28 +28,40 @@ questions:
     subcategory_id: 1
     description: Do you use two-factor authentication?
     detail: Additional info about MFA usage
+    scale_min_text: never used
+    scale_max_text: always used
   - id: 2
     category_id: 10
     subcategory_id: 1
     description: Do you maintain secure coding standards?
     detail: Guidelines for secure development
+    scale_min_text: not at all
+    scale_max_text: fully implemented
   - id: 1
     category_id: 10
     subcategory_id: 2
     description: Are servers regularly updated?
     detail: Patch management processes
+    scale_min_text: never
+    scale_max_text: on schedule
   - id: 2
     category_id: 10
     subcategory_id: 2
     description: Do you monitor network performance?
     detail: Tools used for monitoring
+    scale_min_text: never
+    scale_max_text: continuously
   - id: 1
     category_id: 20
     subcategory_id: 1
     description: Do you have a hiring process?
     detail: Outline of recruitment procedures
+    scale_min_text: none
+    scale_max_text: comprehensive
   - id: 1
     category_id: 30
     subcategory_id: 1
     description: Do you track departmental budgets?
     detail: Methods for monitoring budget spending
+    scale_min_text: not tracked
+    scale_max_text: thoroughly tracked

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -31,6 +31,8 @@ class Question(Base):
     id = Column(Integer, primary_key=True, autoincrement=False)
     description = Column(String, nullable=False)
     detail = Column(String, default="", nullable=True)
+    scale_min_text = Column(String, nullable=True, server_default='')
+    scale_max_text = Column(String, nullable=True, server_default='')
     __table_args__ = (
         ForeignKeyConstraint(['category_id'], ['categories.id']),
         ForeignKeyConstraint(['category_id', 'subcategory_id'], ['subcategories.category_id', 'subcategories.id']),

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -51,6 +51,8 @@ class QuestionBase(BaseModel):
     subcategory_id: int
     description: str
     detail: str | None = None
+    scale_min_text: str | None = None
+    scale_max_text: str | None = None
 
 
 class QuestionCreate(QuestionBase):

--- a/frontend/src/components/CategoryQuestionsForm.tsx
+++ b/frontend/src/components/CategoryQuestionsForm.tsx
@@ -55,12 +55,16 @@ export default function CategoryQuestionsForm({ category, index, total, onSubmit
                   {q.detail}
                 </Form.Text>
               )}
+              {(q.scale_min_text || q.scale_max_text) && (
+                <Form.Text className="text-muted d-block mb-2" style={{ fontSize: 'smaller' }}>
+                  Odpowiedz na skali od 1 do 5, gdzie 1 oznacza <em>{q.scale_min_text}</em> a 5 oznacza <em>{q.scale_max_text}</em>. N/A oznacza, że dany proces nie dotyczy Twojej organizacji i nie będzie uwzględniony w badaniu.
+                </Form.Text>
+              )}
               <div className="d-flex align-items-center">
-                <div className="me-2">
-                  {[1,2,3,4,5].map((n) => (
+                <div className="d-flex flex-grow-1 justify-content-between me-2">
+                  {[1, 2, 3, 4, 5].map((n) => (
                     <Form.Check
                       key={n}
-                      inline
                       type="radio"
                       id={`${q.category_id}_${q.subcategory_id}_${q.id}_${n}`}
                       label={String(n)}
@@ -70,7 +74,6 @@ export default function CategoryQuestionsForm({ category, index, total, onSubmit
                   ))}
                 </div>
                 <Form.Check
-                  inline
                   type="radio"
                   id={`${q.category_id}_${q.subcategory_id}_${q.id}_na`}
                   label="N/A"

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -8,6 +8,8 @@ export interface Question {
   id: number
   description: string
   detail?: string
+  scale_min_text?: string
+  scale_max_text?: string
   category_id: number
   subcategory_id: number
 }


### PR DESCRIPTION
## Summary
- allow specifying scale labels for each question
- use the new labels in CategoryQuestionsForm
- spread scale options evenly across the width
- track label fields in the database and initial data

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6856a81600f483318a30e7f9327d034f