### PR TITLE
Add introductory page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,12 +4,13 @@ import CategoryForm from './components/CategoryForm'
 import ResultsView from './components/ResultsView'
 import MetadataForm from './components/MetadataForm'
 import ReportView from './components/ReportView'
+import IntroPage from './components/IntroPage'
 import { createAssessment } from './api/assessments'
 import { CategoryGroup, Score } from './types'
 import { Container, Button } from 'react-bootstrap'
 
 export default function App() {
-  const [step, setStep] = useState<'start' | 'categories' | 'questions' | 'results' | 'report'>('start')
+  const [step, setStep] = useState<'intro' | 'start' | 'categories' | 'questions' | 'results' | 'report'>('intro')
   const [selectedCategories, setSelectedCategories] = useState<CategoryGroup[]>([])
   const [currentIndex, setCurrentIndex] = useState(0)
   const [results, setResults] = useState<Score[]>([])
@@ -20,6 +21,12 @@ export default function App() {
       createAssessment({ ...metadata, results: results.map(r => r.value) }).catch(() => {})
     }
   }, [step])
+
+  if (step === 'intro') {
+    return (
+      <IntroPage onStart={() => setStep('start')} onReport={() => setStep('report')} />
+    )
+  }
 
   if (step === 'start') {
     return (
@@ -70,7 +77,7 @@ export default function App() {
     return (
       <Container className="mt-4">
         <ResultsView results={results || []} categories={selectedCategories} />
-        <Button className="mt-3" onClick={() => setStep('start')}>Strona główna</Button>
+        <Button className="mt-3" onClick={() => setStep('intro')}>Strona główna</Button>
       </Container>
     )
   }
@@ -78,7 +85,7 @@ export default function App() {
   return (
     <Container className="mt-4">
       <ReportView />
-      <Button className="mt-3" onClick={() => setStep('start')}>Powrót</Button>
+      <Button className="mt-3" onClick={() => setStep('intro')}>Powrót</Button>
     </Container>
   )
 }

--- a/frontend/src/components/IntroPage.tsx
+++ b/frontend/src/components/IntroPage.tsx
@@ -1,0 +1,23 @@
+import { Container, Button } from 'react-bootstrap'
+
+interface Props {
+  onStart: () => void
+  onReport: () => void
+}
+
+export default function IntroPage({ onStart, onReport }: Props) {
+  return (
+    <Container className="mt-4">
+      <h1>Badanie samooceny</h1>
+      <p>
+        Niniejszy kwestionariusz pozwala ocenić stopień wdrożenia standardów
+        w Twojej organizacji. Odpowiadaj szczerze na kolejne pytania. Jeśli
+        dane zagadnienie Cię nie dotyczy, wybierz opcję "N/A".
+      </p>
+      <div className="d-flex gap-2 mt-3">
+        <Button onClick={onStart}>Rozpocznij badanie</Button>
+        <Button variant="secondary" onClick={onReport}>Raporty</Button>
+      </div>
+    </Container>
+  )
+}

--- a/frontend/src/components/__tests__/IntroPage.test.tsx
+++ b/frontend/src/components/__tests__/IntroPage.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import IntroPage from '../IntroPage'
+
+describe('IntroPage', () => {
+  it('calls onStart when button clicked', async () => {
+    const start = vi.fn()
+    render(<IntroPage onStart={start} onReport={() => {}} />)
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /Rozpocznij/ }))
+    expect(start).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- introduce new IntroPage component with start instructions
- start app on IntroPage and return to it from other steps
- test IntroPage behaviour

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ac74079883318e153abd81264bee