### PR TITLE
Validate all questions answered

### DIFF
--- a/frontend/src/components/CategoryQuestionsForm.tsx
+++ b/frontend/src/components/CategoryQuestionsForm.tsx
@@ -16,13 +16,19 @@ export default function CategoryQuestionsForm({ category, index, total, onSubmit
   const { register, handleSubmit } = useForm<Record<string, string>>({})
   const [questions, setQuestions] = useState<Question[]>([])
   const [subcategories, setSubcategories] = useState<Subcategory[]>([])
+  const [answers, setAnswers] = useState<Record<string, string>>({})
 
   useEffect(() => {
     getQuestions(category.ids).then(setQuestions)
     getSubcategories(category.ids).then(setSubcategories)
   }, [category.ids])
 
+  const allAnswered = questions.every(q => answers[`${q.category_id}_${q.subcategory_id}_${q.id}`])
+
   const submit = handleSubmit((data) => {
+    if (!allAnswered) {
+      return
+    }
     const scores: Score[] = questions.map((q) => {
       const val = data[`${q.category_id}_${q.subcategory_id}_${q.id}`]
       const num = val === 'NA' || val === undefined || val === '' ? 0 : Number(val)
@@ -70,6 +76,12 @@ export default function CategoryQuestionsForm({ category, index, total, onSubmit
                       label={String(n)}
                       value={n}
                       {...register(`${q.category_id}_${q.subcategory_id}_${q.id}`)}
+                      onChange={(e) =>
+                        setAnswers((prev) => ({
+                          ...prev,
+                          [`${q.category_id}_${q.subcategory_id}_${q.id}`]: (e.target as HTMLInputElement).value,
+                        }))
+                      }
                     />
                   ))}
                 </div>
@@ -80,13 +92,21 @@ export default function CategoryQuestionsForm({ category, index, total, onSubmit
                   value="NA"
                   className="text-secondary"
                   {...register(`${q.category_id}_${q.subcategory_id}_${q.id}`)}
+                  onChange={(e) =>
+                    setAnswers((prev) => ({
+                      ...prev,
+                      [`${q.category_id}_${q.subcategory_id}_${q.id}`]: (e.target as HTMLInputElement).value,
+                    }))
+                  }
                 />
               </div>
             </Form.Group>
           ))}
         </div>
       ))}
-      <Button type="submit">{index + 1 === total ? 'Zakończ' : 'Dalej'}</Button>
+      <Button type="submit" disabled={!allAnswered}>
+        {index + 1 === total ? 'Zakończ' : 'Dalej'}
+      </Button>
     </Form>
   )
 }

--- a/frontend/src/components/__tests__/CategoryQuestionsForm.test.tsx
+++ b/frontend/src/components/__tests__/CategoryQuestionsForm.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { vi, describe, it, expect } from 'vitest'
 import CategoryQuestionsForm from '../CategoryQuestionsForm'
 import { CategoryGroup } from '../../types'
@@ -30,5 +31,20 @@ describe('CategoryQuestionsForm', () => {
     // question details
     expect(await screen.findByText('qd1')).toBeInTheDocument()
     expect(await screen.findByText('qd2')).toBeInTheDocument()
+  })
+
+  it('disables submit button until all questions answered', async () => {
+    const submit = vi.fn()
+    render(<CategoryQuestionsForm category={category} index={0} total={1} onSubmit={submit} />)
+    const user = userEvent.setup()
+    const button = await screen.findByRole('button', { name: /Zakończ/ })
+    expect(button).toBeDisabled()
+    const radios = await screen.findAllByRole('radio', { name: '1' })
+    await user.click(radios[0])
+    expect(button).toBeDisabled()
+    await user.click(radios[1])
+    expect(button).toBeEnabled()
+    await user.click(button)
+    expect(submit).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- require answering all questions on a page before allowing submission
- test that submit button stays disabled until all questions are answered

## Testing
- `npx vitest run`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856b02626108331b57ecff3a87240d8