### PR TITLE
Add icons for categories

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "react-bootstrap": "^2.9.2",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.45.0",
-    "recharts": "^2.6.2"
+    "recharts": "^2.6.2",
+    "react-icons": "^4.10.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/frontend/src/components/CategoryForm.tsx
+++ b/frontend/src/components/CategoryForm.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import axios from 'axios'
 import { CategoryGroup, Category } from '../types'
 import { Form, Button, Row, Col, Card } from 'react-bootstrap'
+import { FaLaptop, FaUsers, FaMoneyBillAlt, FaQuestionCircle } from 'react-icons/fa'
 
 interface Props {
   onSubmit: (categories: CategoryGroup[]) => void
@@ -36,30 +37,39 @@ export default function CategoryForm({ onSubmit }: Props) {
     onSubmit(categories.filter(c => selected.includes(c.id)))
   }
 
+  const getIcon = (name: string) => {
+    switch (name) {
+      case 'IT':
+        return <FaLaptop className="category-icon" />
+      case 'HR':
+        return <FaUsers className="category-icon" />
+      case 'Finance':
+        return <FaMoneyBillAlt className="category-icon" />
+      default:
+        return <FaQuestionCircle className="category-icon" />
+    }
+  }
+
   return (
     <Form onSubmit={submit} className="w-100 text-center">
       <p className="mb-4">
         Wybierz kategorie, które chcesz zbadać dla swojej organizacji. Zalecane jest wybranie kategorii, które mają zastosowanie dla Twojej organizacji i które w niej realizujesz lub chcesz realizować.
       </p>
       <Row xs={1} sm={2} md={3} className="g-4 justify-content-center">
-        {categories.map((c, idx) => {
-          const color1 = `hsl(${(idx * 60) % 360}, 70%, 90%)`
-          const color2 = `hsl(${(idx * 60) % 360}, 70%, 80%)`
-          return (
-            <Col key={c.id}>
-              <Card
-                className={`category-card h-100 ${selected.includes(c.id) ? 'selected' : ''}`}
-                style={{ background: `linear-gradient(135deg, ${color1}, ${color2})` }}
-                onClick={() => toggle(c.id)}
-              >
-                {selected.includes(c.id) && <span className="check-icon">✓</span>}
-                <Card.Body className="d-flex justify-content-center align-items-center">
-                  <span className="category-label">{c.name}</span>
-                </Card.Body>
-              </Card>
-            </Col>
-          )
-        })}
+        {categories.map((c) => (
+          <Col key={c.id}>
+            <Card
+              className={`category-card h-100 ${selected.includes(c.id) ? 'selected' : ''}`}
+              onClick={() => toggle(c.id)}
+            >
+              {selected.includes(c.id) && <span className="check-icon">✓</span>}
+              <Card.Body className="d-flex flex-column justify-content-center align-items-center">
+                {getIcon(c.name)}
+                <span className="category-label">{c.name}</span>
+              </Card.Body>
+            </Card>
+          </Col>
+        ))}
       </Row>
       <Button type="submit" className="mt-3" disabled={!selected.length}>Dalej</Button>
     </Form>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -25,7 +25,7 @@
   right: 0.5rem;
   width: 1.5rem;
   height: 1.5rem;
-  background-color: #0d6efd;
+  background-color: #6c757d;
   color: #fff;
   border-radius: 50%;
   display: flex;
@@ -38,4 +38,9 @@
 .category-label {
   font-size: 1.25rem;
   font-weight: 500;
+}
+
+.category-icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- update CategoryForm with elegant icons and remove coloured backgrounds
- use react-icons and add simple icon CSS
- tone down selection badge colour

## Testing
- `npm run test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6856bafc3d4c83319265cd0dfab79e43