### PR TITLE
Fix deprecated API usage

### DIFF
--- a/app/api/categories.py
+++ b/app/api/categories.py
@@ -11,7 +11,7 @@ router = APIRouter(prefix="/api/categories", tags=["categories"])
 
 @router.post("/", response_model=CategoryRead)
 def create_category(category: CategoryCreate, db: Session = Depends(get_db)):
-    db_obj = Category(**category.dict())
+    db_obj = Category(**category.model_dump())
     db.add(db_obj)
     db.commit()
     db.refresh(db_obj)

--- a/app/api/processes.py
+++ b/app/api/processes.py
@@ -10,7 +10,7 @@ router = APIRouter(prefix="/api/processes", tags=["processes"])
 
 @router.post("/", response_model=ProcessRead)
 def create_process(process: ProcessCreate, db: Session = Depends(get_db)):
-    db_obj = Process(**process.dict())
+    db_obj = Process(**process.model_dump())
     db.add(db_obj)
     db.commit()
     db.refresh(db_obj)

--- a/app/api/questions.py
+++ b/app/api/questions.py
@@ -11,7 +11,7 @@ router = APIRouter(prefix="/api/questions", tags=["questions"])
 
 @router.post("/", response_model=QuestionRead)
 def create_question(question: QuestionCreate, db: Session = Depends(get_db)):
-    db_obj = Question(**question.dict())
+    db_obj = Question(**question.model_dump())
     db.add(db_obj)
     db.commit()
     db.refresh(db_obj)

--- a/app/api/scoring.py
+++ b/app/api/scoring.py
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/api/scoring", tags=["scoring"])
 def score_processes(scores: List[ScoreInput], db: Session = Depends(get_db)):
     results = []
     for s in scores:
-        process = db.query(Process).get(s.process_id)
+        process = db.get(Process, s.process_id)
         if not process or s.score is None:
             continue
         results.append(s.score)

--- a/app/api/subcategories.py
+++ b/app/api/subcategories.py
@@ -11,7 +11,7 @@ router = APIRouter(prefix="/api/subcategories", tags=["subcategories"])
 
 @router.post("/", response_model=SubcategoryRead)
 def create_subcategory(subcat: SubcategoryCreate, db: Session = Depends(get_db)):
-    db_obj = Subcategory(**subcat.dict())
+    db_obj = Subcategory(**subcat.model_dump())
     db.add(db_obj)
     db.commit()
     db.refresh(db_obj)

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from contextlib import asynccontextmanager
 
 from app.data_loader import load_initial_data
 
@@ -9,12 +10,12 @@ from app.api.subcategories import router as subcategories_router
 from app.api.questions import router as questions_router
 from app.api.assessments import router as assessments_router
 
-app = FastAPI()
-
-
-@app.on_event("startup")
-def _load_data() -> None:
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     load_initial_data()
+    yield
+
+app = FastAPI(lifespan=lifespan)
 
 app.include_router(processes_router)
 app.include_router(scoring_router)

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String, ForeignKey, ForeignKeyConstraint, JSON, DateTime
 from sqlalchemy.orm import declarative_base
-from datetime import datetime
+from datetime import datetime, UTC
 
 Base = declarative_base()
 
@@ -45,4 +45,4 @@ class Assessment(Base):
     employees_range = Column(String, nullable=False)
     volunteers_range = Column(String, nullable=False)
     results = Column(JSON, nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: datetime.now(UTC))

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,5 +1,5 @@
 from typing import Optional, List
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from datetime import datetime
 
 class ProcessBase(BaseModel):
@@ -11,8 +11,7 @@ class ProcessCreate(ProcessBase):
 
 class ProcessRead(ProcessBase):
     id: int
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CategoryBase(BaseModel):
@@ -25,8 +24,7 @@ class CategoryCreate(CategoryBase):
 
 
 class CategoryRead(CategoryBase):
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class SubcategoryBase(BaseModel):
@@ -41,8 +39,7 @@ class SubcategoryCreate(SubcategoryBase):
 
 
 class SubcategoryRead(SubcategoryBase):
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class QuestionBase(BaseModel):
@@ -60,8 +57,7 @@ class QuestionCreate(QuestionBase):
 
 
 class QuestionRead(QuestionBase):
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class ScoreInput(BaseModel):
     process_id: int
@@ -81,6 +77,4 @@ class AssessmentCreate(AssessmentBase):
 class AssessmentRead(AssessmentBase):
     id: int
     created_at: datetime
-
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- replace deprecated `dict()` usage with `model_dump`
- use new Pydantic `ConfigDict` for ORM models
- switch FastAPI startup handler to a lifespan function
- use `Session.get()` instead of deprecated `Query.get()`
- create timezone-aware timestamps

## Testing
- `pytest -q`
- `pytest -q -W error`


------
https://chatgpt.com/codex/tasks/task_e_6856c89b84348331878b4495aa12ba1e