### PR TITLE
Indente questions and add spacing

### DIFF
--- a/frontend/src/components/CategoryQuestionsForm.tsx
+++ b/frontend/src/components/CategoryQuestionsForm.tsx
@@ -41,8 +41,8 @@ export default function CategoryQuestionsForm({ category, index, total, onSubmit
     <Form onSubmit={submit} className="w-100">
       <h3>{category.name}</h3>
       <ProgressBar now={((index + 1) / total) * 100} label={`${index + 1}/${total}`} className="mb-3" />
-      {subcategories.map((sub) => (
-        <div key={sub.id} className="mb-4">
+        {subcategories.map((sub) => (
+          <div key={sub.id} className="mb-5">
           <Form.Group>
             <Form.Label as="h5" className="mb-0">
               {sub.name}
@@ -53,8 +53,8 @@ export default function CategoryQuestionsForm({ category, index, total, onSubmit
               </Form.Text>
             )}
           </Form.Group>
-          {questions.filter((q) => q.subcategory_id === sub.id).map((q) => (
-            <Form.Group key={q.id} className="mb-3">
+            {questions.filter((q) => q.subcategory_id === sub.id).map((q) => (
+              <Form.Group key={q.id} className="mb-4 ms-4">
               <Form.Label>{q.description}</Form.Label>
               {q.detail && (
                 <Form.Text className="text-muted d-block mb-1" style={{ fontSize: 'smaller' }}>


### PR DESCRIPTION
## Summary
- indent questions within each subcategory
- increase spacing between subcategories and between questions

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ca3dfd7c8331806cb510e455ff70