### PR TITLE
Update question scale UI

### DIFF
--- a/frontend/src/components/CategoryQuestionsForm.tsx
+++ b/frontend/src/components/CategoryQuestionsForm.tsx
@@ -82,11 +82,11 @@ export default function CategoryQuestionsForm({ category, index, total, onSubmit
               )}
               {(q.scale_min_text || q.scale_max_text) && (
                 <Form.Text className="text-muted d-block mb-2" style={{ fontSize: 'smaller' }}>
-                  Odpowiedz na skali od 1 do 5, gdzie 1 oznacza <em>{q.scale_min_text}</em> a 5 oznacza <em>{q.scale_max_text}</em>. N/A oznacza, że dany proces nie dotyczy Twojej organizacji i nie będzie uwzględniony w badaniu.
+                  Odpowiedz na skali od 1 do 5. N/A oznacza, że dany proces nie dotyczy Twojej organizacji i nie będzie uwzględniony w badaniu.
                 </Form.Text>
               )}
               <div className="d-flex align-items-center">
-                <div className="d-flex flex-grow-1 justify-content-between me-2">
+                <div className="d-flex flex-grow-1 justify-content-between me-2 position-relative pb-3">
                   {[1, 2, 3, 4, 5].map((n) => (
                     <Form.Check
                       key={n}
@@ -94,6 +94,7 @@ export default function CategoryQuestionsForm({ category, index, total, onSubmit
                       id={`${q.category_id}_${q.subcategory_id}_${q.id}_${n}`}
                       label={String(n)}
                       value={n}
+                      className="text-center flex-fill"
                       {...register(`${q.category_id}_${q.subcategory_id}_${q.id}`)}
                       onChange={(e) =>
                         setAnswers((prev) => ({
@@ -103,6 +104,16 @@ export default function CategoryQuestionsForm({ category, index, total, onSubmit
                       }
                     />
                   ))}
+                  {(q.scale_min_text || q.scale_max_text) && (
+                    <div className="position-absolute w-100 d-flex justify-content-between scale-labels px-1">
+                      {q.scale_min_text && (
+                        <Form.Text className="text-muted">{q.scale_min_text}</Form.Text>
+                      )}
+                      {q.scale_max_text && (
+                        <Form.Text className="text-muted text-end">{q.scale_max_text}</Form.Text>
+                      )}
+                    </div>
+                  )}
                 </div>
                 <Form.Check
                   type="radio"

--- a/frontend/src/components/__tests__/CategoryQuestionsForm.test.tsx
+++ b/frontend/src/components/__tests__/CategoryQuestionsForm.test.tsx
@@ -6,7 +6,15 @@ import { CategoryGroup } from '../../types'
 
 vi.mock('../../api/questions', () => ({
   getQuestions: vi.fn(() => Promise.resolve([
-    { id: 1, description: 'Q1', detail: 'qd1', category_id: 1, subcategory_id: 10 },
+    {
+      id: 1,
+      description: 'Q1',
+      detail: 'qd1',
+      category_id: 1,
+      subcategory_id: 10,
+      scale_min_text: 'min',
+      scale_max_text: 'max',
+    },
     { id: 2, description: 'Q2', detail: 'qd2', category_id: 1, subcategory_id: 20 },
   ]))
 }))
@@ -36,6 +44,12 @@ describe('CategoryQuestionsForm', () => {
 
     // second subcategory now visible
     expect(await screen.findByText('subdesc2')).toBeInTheDocument()
+  })
+
+  it('shows scale labels below 1 and 5', async () => {
+    render(<CategoryQuestionsForm category={category} index={0} total={1} onSubmit={() => {}} />)
+    expect(await screen.findByText('min')).toBeInTheDocument()
+    expect(screen.getByText('max')).toBeInTheDocument()
   })
 
   it('disables submit button until questions in each subcategory answered', async () => {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -44,3 +44,9 @@
   font-size: 2rem;
   margin-bottom: 0.5rem;
 }
+
+.scale-labels {
+  font-size: smaller;
+  top: 100%;
+  left: 0;
+}


### PR DESCRIPTION
## Summary
- show text for 1 and 5 directly below the rating without distorting layout
- add CSS helper class for absolutely positioned scale labels

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68597dd9808c8331b974103a5e51aee9