### PR TITLE
Add category icons to results

### DIFF
--- a/frontend/src/components/CategoryForm.tsx
+++ b/frontend/src/components/CategoryForm.tsx
@@ -2,21 +2,7 @@ import { useEffect, useState } from 'react'
 import axios from 'axios'
 import { CategoryGroup, Category } from '../types'
 import { Form, Button, Row, Col, Card } from 'react-bootstrap'
-import {
-  FaLaptop,
-  FaUsers,
-  FaMoneyBillAlt,
-  FaQuestionCircle,
-  FaLightbulb,
-  FaCogs,
-  FaBullhorn,
-  FaTruck,
-  FaHeadset,
-  FaBuilding,
-  FaShieldAlt,
-  FaHandshake,
-  FaChartLine,
-} from 'react-icons/fa'
+import CategoryIcon from './CategoryIcon'
 
 interface Props {
   onSubmit: (categories: CategoryGroup[]) => void
@@ -51,36 +37,6 @@ export default function CategoryForm({ onSubmit }: Props) {
     onSubmit(categories.filter(c => selected.includes(c.id)))
   }
 
-  const getIcon = (id: number) => {
-    switch (id) {
-      case 1:
-        return <FaLightbulb className="category-icon" />
-      case 2:
-        return <FaCogs className="category-icon" />
-      case 3:
-        return <FaBullhorn className="category-icon" />
-      case 5:
-        return <FaTruck className="category-icon" />
-      case 6:
-        return <FaHeadset className="category-icon" />
-      case 7:
-        return <FaUsers className="category-icon" />
-      case 8:
-        return <FaLaptop className="category-icon" />
-      case 9:
-        return <FaMoneyBillAlt className="category-icon" />
-      case 10:
-        return <FaBuilding className="category-icon" />
-      case 11:
-        return <FaShieldAlt className="category-icon" />
-      case 12:
-        return <FaHandshake className="category-icon" />
-      case 13:
-        return <FaChartLine className="category-icon" />
-      default:
-        return <FaQuestionCircle className="category-icon" />
-    }
-  }
 
   return (
     <Form onSubmit={submit} className="w-100 text-center">
@@ -96,7 +52,7 @@ export default function CategoryForm({ onSubmit }: Props) {
             >
               {selected.includes(c.id) && <span className="check-icon">✓</span>}
               <Card.Body className="d-flex flex-column justify-content-center align-items-center">
-                {getIcon(c.id)}
+                <CategoryIcon id={c.id} />
                 <span className="category-label">{c.name}</span>
               </Card.Body>
             </Card>

--- a/frontend/src/components/CategoryIcon.tsx
+++ b/frontend/src/components/CategoryIcon.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import {
+  FaLaptop,
+  FaUsers,
+  FaMoneyBillAlt,
+  FaQuestionCircle,
+  FaLightbulb,
+  FaCogs,
+  FaBullhorn,
+  FaTruck,
+  FaHeadset,
+  FaBuilding,
+  FaShieldAlt,
+  FaHandshake,
+  FaChartLine,
+} from 'react-icons/fa'
+
+interface Props {
+  id: number
+  className?: string
+}
+
+export default function CategoryIcon({ id, className = 'category-icon' }: Props) {
+  switch (id) {
+    case 1:
+      return <FaLightbulb className={className} />
+    case 2:
+      return <FaCogs className={className} />
+    case 3:
+      return <FaBullhorn className={className} />
+    case 5:
+      return <FaTruck className={className} />
+    case 6:
+      return <FaHeadset className={className} />
+    case 7:
+      return <FaUsers className={className} />
+    case 8:
+      return <FaLaptop className={className} />
+    case 9:
+      return <FaMoneyBillAlt className={className} />
+    case 10:
+      return <FaBuilding className={className} />
+    case 11:
+      return <FaShieldAlt className={className} />
+    case 12:
+      return <FaHandshake className={className} />
+    case 13:
+      return <FaChartLine className={className} />
+    default:
+      return <FaQuestionCircle className={className} />
+  }
+}

--- a/frontend/src/components/ResultsView.tsx
+++ b/frontend/src/components/ResultsView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Accordion, ListGroup } from 'react-bootstrap'
+import CategoryIcon from './CategoryIcon'
 import { CategoryGroup, Score, Subcategory } from '../types'
 import { getSubcategories } from '../api/subcategories'
 
@@ -51,6 +52,7 @@ export default function ResultsView({ results, categories }: Props) {
         {catData.map((c, idx) => (
           <Accordion.Item eventKey={String(idx)} key={c.category.id}>
             <Accordion.Header>
+              <CategoryIcon id={c.category.id} className="me-2" />
               {c.category.name} –{' '}
               <span className={scoreClass(c.avg)}>{c.avg.toFixed(2)}/5.0</span>
             </Accordion.Header>


### PR DESCRIPTION
## Summary
- factor out `CategoryIcon` component
- use `CategoryIcon` in `CategoryForm` and `ResultsView`
- display icon before category name in results accordion

## Testing
- `npm --prefix frontend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a738d13888331a3d8c6a3f01f9a9a