### PR TITLE
Add score explanation section

### DIFF
--- a/frontend/src/components/ResultsView.tsx
+++ b/frontend/src/components/ResultsView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Accordion, ListGroup } from 'react-bootstrap'
+import { Accordion, ListGroup, Card } from 'react-bootstrap'
 import CategoryIcon from './CategoryIcon'
 import { CategoryGroup, Score, Subcategory } from '../types'
 import { getSubcategories } from '../api/subcategories'
@@ -41,6 +41,17 @@ export default function ResultsView({ results, categories }: Props) {
     if (value > 0) return 'text-danger'
     return 'text-secondary'
   }
+
+  const highlightLevels = () => {
+    if (overall <= 0) return [] as number[]
+    const base = Math.floor(overall)
+    if (base >= 5) return [5]
+    const lvl = Math.max(1, base)
+    return [lvl, lvl + 1]
+  }
+
+  const highlightClass = (level: number) =>
+    highlightLevels().includes(level) ? 'list-group-item-info' : ''
 
   return (
     <div className="w-100">
@@ -84,6 +95,34 @@ export default function ResultsView({ results, categories }: Props) {
           </Accordion.Item>
         ))}
       </Accordion>
+
+      <Card className="mt-4">
+        <Card.Body>
+          <Card.Title as="h5">Co oznacza mój wynik?</Card.Title>
+          <ListGroup variant="flush" className="mt-2">
+            <ListGroup.Item className={highlightClass(1)}>
+              <strong>Poziom 1 – Początkowy</strong>
+              <div>Na tym etapie Twoje procesy są w dużej mierze improwizowane. Brakuje stałych procedur i dokumentacji, a to, czy zadania zostaną wykonane poprawnie, zależy głównie od indywidualnych umiejętności kluczowych osób. W rezultacie praca bywa chaotyczna, a wyniki nieprzewidywalne.</div>
+            </ListGroup.Item>
+            <ListGroup.Item className={highlightClass(2)}>
+              <strong>Poziom 2 – Powtarzalny</strong>
+              <div>Masz już zdefiniowane najważniejsze kroki procesów, dzięki czemu zespół może je odtwarzać w podobny sposób za każdym razem. To umożliwia bardziej wiarygodne planowanie i oszacowanie zasobów w oparciu o wcześniejsze doświadczenia. Nadal jednak dopracowanie szczegółów odbywa się głównie „w locie”.</div>
+            </ListGroup.Item>
+            <ListGroup.Item className={highlightClass(3)}>
+              <strong>Poziom 3 – Zdefiniowany</strong>
+              <div>Twoje procesy zostały sformalizowane i udokumentowane w całej organizacji. Każdy wie, jakie kroki powinien podjąć, a narzędzia, role i odpowiedzialności są jasno określone. Daje to spójność wykonania, lepszą kontrolę nad kosztami, terminami i jakością dostarczanych usług.</div>
+            </ListGroup.Item>
+            <ListGroup.Item className={highlightClass(4)}>
+              <strong>Poziom 4 – Zarządzany</strong>
+              <div>Procesy są nie tylko stosowane, ale też mierzone w czasie rzeczywistym. Regularnie zbierasz dane o wydajności i odchyleniach od założeń, co pozwala prognozować potencjalne problemy i podejmować korekty, zanim zbyt mocno odbiegniesz od oczekiwań. Decyzje opierają się na spójnych analizach.</div>
+            </ListGroup.Item>
+            <ListGroup.Item className={highlightClass(5)}>
+              <strong>Poziom 5 – Optymalizujący</strong>
+              <div>Twoja organizacja działa w trybie ciągłego doskonalenia: regularnie identyfikujecie słabe ogniwa, eksperymentujecie z ulepszeniami i wdrażacie innowacje, które podnoszą efektywność. Zespoły samodzielnie proponują usprawnienia, a kultura organizacyjna sprzyja szybkiemu testowaniu i skalowaniu najlepszych praktyk.</div>
+            </ListGroup.Item>
+          </ListGroup>
+        </Card.Body>
+      </Card>
     </div>
   )
 }

--- a/frontend/src/components/__tests__/ResultsView.test.tsx
+++ b/frontend/src/components/__tests__/ResultsView.test.tsx
@@ -47,4 +47,13 @@ describe('ResultsView', () => {
     expect(await screen.findByText(/Sub1/)).toBeInTheDocument()
     expect((await screen.findAllByText('4.00/5.0')).length).toBeGreaterThan(0)
   })
+
+  it('displays explanation section with highlighted levels', async () => {
+    render(<ResultsView results={results} categories={[categories[0]]} />)
+    expect(await screen.findByRole('heading', { name: /Co oznacza mój wynik\?/ })).toBeInTheDocument()
+    const lvl3 = screen.getByText(/Poziom 3/)
+    const lvl4 = screen.getByText(/Poziom 4/)
+    expect(lvl3.closest('.list-group-item')).toHaveClass('list-group-item-info')
+    expect(lvl4.closest('.list-group-item')).toHaveClass('list-group-item-info')
+  })
 })


### PR DESCRIPTION
## Summary
- add card with level explanations to results page
- highlight matching levels when overall score falls within a range
- test display and highlight logic

## Testing
- `npm test --prefix frontend --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a74bab61483319f02a5f7f7a64902