### PR TITLE
Add improvement card and reorganize results view

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import CategoryQuestionsForm from './components/CategoryQuestionsForm'
 import CategoryForm from './components/CategoryForm'
 import ResultsView from './components/ResultsView'
+import ProcessImprovement from './components/ProcessImprovement'
 import MetadataForm from './components/MetadataForm'
 import ReportView from './components/ReportView'
 import IntroPage from './components/IntroPage'
@@ -10,7 +11,7 @@ import { CategoryGroup, Score } from './types'
 import { Container, Button } from 'react-bootstrap'
 
 export default function App() {
-  const [step, setStep] = useState<'intro' | 'start' | 'categories' | 'questions' | 'results' | 'report'>('intro')
+  const [step, setStep] = useState<'intro' | 'start' | 'categories' | 'questions' | 'results' | 'improvement' | 'report'>('intro')
   const [selectedCategories, setSelectedCategories] = useState<CategoryGroup[]>([])
   const [currentIndex, setCurrentIndex] = useState(0)
   const [results, setResults] = useState<Score[]>([])
@@ -79,9 +80,15 @@ export default function App() {
     return (
       <Container className="mt-4 d-flex flex-column align-items-center">
         <h2 className="mb-3">Wyniki</h2>
-        <ResultsView results={results || []} categories={selectedCategories} />
+        <ResultsView results={results || []} categories={selectedCategories} onImprove={() => setStep('improvement')} />
         <Button className="mt-3" onClick={() => setStep('intro')}>Strona główna</Button>
       </Container>
+    )
+  }
+
+  if (step === 'improvement') {
+    return (
+      <ProcessImprovement onBack={() => setStep('results')} />
     )
   }
 

--- a/frontend/src/components/ProcessImprovement.tsx
+++ b/frontend/src/components/ProcessImprovement.tsx
@@ -1,0 +1,15 @@
+import { Container, Button } from 'react-bootstrap'
+
+interface Props {
+  onBack: () => void
+}
+
+export default function ProcessImprovement({ onBack }: Props) {
+  return (
+    <Container className="mt-4 d-flex flex-column align-items-center">
+      <h2 className="mb-3">Usprawnienie procesów</h2>
+      <p>Tutaj pojawią się wskazówki dotyczące usprawniania procesów.</p>
+      <Button className="mt-3" onClick={onBack}>Powrót</Button>
+    </Container>
+  )
+}

--- a/frontend/src/components/ResultsView.tsx
+++ b/frontend/src/components/ResultsView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Accordion, ListGroup, Card } from 'react-bootstrap'
+import { Accordion, ListGroup, Card, Button } from 'react-bootstrap'
 import CategoryIcon from './CategoryIcon'
 import { CategoryGroup, Score, Subcategory } from '../types'
 import { getSubcategories } from '../api/subcategories'
@@ -7,9 +7,10 @@ import { getSubcategories } from '../api/subcategories'
 interface Props {
   results: Score[]
   categories: CategoryGroup[]
+  onImprove: () => void
 }
 
-export default function ResultsView({ results, categories }: Props) {
+export default function ResultsView({ results, categories, onImprove }: Props) {
   const [subcategories, setSubcategories] = useState<Subcategory[]>([])
 
   useEffect(() => {
@@ -59,6 +60,37 @@ export default function ResultsView({ results, categories }: Props) {
         Średni wynik całości:{' '}
         <span className={scoreClass(overall)}>{overall.toFixed(2)}/5.0</span>
       </h4>
+      <Card className="mt-3">
+        <Card.Body>
+          <Card.Title as="h5">Co oznacza mój wynik?</Card.Title>
+          <ListGroup variant="flush" className="mt-2">
+            <ListGroup.Item className={highlightClass(1)}>
+              <strong>Poziom 1 – Początkowy</strong>
+              <div>Na tym etapie Twoje procesy są w dużej mierze improwizowane. Brakuje stałych procedur i dokumentacji, a to, czy zadania zostaną wykonane poprawnie, zależy głównie od indywidualnych umiejętności kluczowych osób. W rezultacie praca bywa chaotyczna, a wyniki nieprzewidywalne.</div>
+            </ListGroup.Item>
+            <ListGroup.Item className={highlightClass(2)}>
+              <strong>Poziom 2 – Powtarzalny</strong>
+              <div>Masz już zdefiniowane najważniejsze kroki procesów, dzięki czemu zespół może je odtwarzać w podobny sposób za każdym razem. To umożliwia bardziej wiarygodne planowanie i oszacowanie zasobów w oparciu o wcześniejsze doświadczenia. Nadal jednak dopracowanie szczegółów odbywa się głównie „w locie”.</div>
+            </ListGroup.Item>
+            <ListGroup.Item className={highlightClass(3)}>
+              <strong>Poziom 3 – Zdefiniowany</strong>
+              <div>Twoje procesy zostały sformalizowane i udokumentowane w całej organizacji. Każdy wie, jakie kroki powinien podjąć, a narzędzia, role i odpowiedzialności są jasno określone. Daje to spójność wykonania, lepszą kontrolę nad kosztami, terminami i jakością dostarczanych usług.</div>
+            </ListGroup.Item>
+            <ListGroup.Item className={highlightClass(4)}>
+              <strong>Poziom 4 – Zarządzany</strong>
+              <div>Procesy są nie tylko stosowane, ale też mierzone w czasie rzeczywistym. Regularnie zbierasz dane o wydajności i odchyleniach od założeń, co pozwala prognozować potencjalne problemy i podejmować korekty, zanim zbyt mocno odbiegniesz od oczekiwań. Decyzje opierają się na spójnych analizach.</div>
+            </ListGroup.Item>
+            <ListGroup.Item className={highlightClass(5)}>
+              <strong>Poziom 5 – Optymalizujący</strong>
+              <div>Twoja organizacja działa w trybie ciągłego doskonalenia: regularnie identyfikujecie słabe ogniwa, eksperymentujecie z ulepszeniami i wdrażacie innowacje, które podnoszą efektywność. Zespoły samodzielnie proponują usprawnienia, a kultura organizacyjna sprzyja szybkiemu testowaniu i skalowaniu najlepszych praktyk.</div>
+            </ListGroup.Item>
+          </ListGroup>
+          <Button className="mt-3" onClick={onImprove}>Usprawnij procesy</Button>
+        </Card.Body>
+      </Card>
+
+      <h5 className="mt-4">Wyniki szczegółowe</h5>
+
       <Accordion className="mt-3" alwaysOpen>
         {catData.map((c, idx) => (
           <Accordion.Item eventKey={String(idx)} key={c.category.id}>
@@ -95,34 +127,6 @@ export default function ResultsView({ results, categories }: Props) {
           </Accordion.Item>
         ))}
       </Accordion>
-
-      <Card className="mt-4">
-        <Card.Body>
-          <Card.Title as="h5">Co oznacza mój wynik?</Card.Title>
-          <ListGroup variant="flush" className="mt-2">
-            <ListGroup.Item className={highlightClass(1)}>
-              <strong>Poziom 1 – Początkowy</strong>
-              <div>Na tym etapie Twoje procesy są w dużej mierze improwizowane. Brakuje stałych procedur i dokumentacji, a to, czy zadania zostaną wykonane poprawnie, zależy głównie od indywidualnych umiejętności kluczowych osób. W rezultacie praca bywa chaotyczna, a wyniki nieprzewidywalne.</div>
-            </ListGroup.Item>
-            <ListGroup.Item className={highlightClass(2)}>
-              <strong>Poziom 2 – Powtarzalny</strong>
-              <div>Masz już zdefiniowane najważniejsze kroki procesów, dzięki czemu zespół może je odtwarzać w podobny sposób za każdym razem. To umożliwia bardziej wiarygodne planowanie i oszacowanie zasobów w oparciu o wcześniejsze doświadczenia. Nadal jednak dopracowanie szczegółów odbywa się głównie „w locie”.</div>
-            </ListGroup.Item>
-            <ListGroup.Item className={highlightClass(3)}>
-              <strong>Poziom 3 – Zdefiniowany</strong>
-              <div>Twoje procesy zostały sformalizowane i udokumentowane w całej organizacji. Każdy wie, jakie kroki powinien podjąć, a narzędzia, role i odpowiedzialności są jasno określone. Daje to spójność wykonania, lepszą kontrolę nad kosztami, terminami i jakością dostarczanych usług.</div>
-            </ListGroup.Item>
-            <ListGroup.Item className={highlightClass(4)}>
-              <strong>Poziom 4 – Zarządzany</strong>
-              <div>Procesy są nie tylko stosowane, ale też mierzone w czasie rzeczywistym. Regularnie zbierasz dane o wydajności i odchyleniach od założeń, co pozwala prognozować potencjalne problemy i podejmować korekty, zanim zbyt mocno odbiegniesz od oczekiwań. Decyzje opierają się na spójnych analizach.</div>
-            </ListGroup.Item>
-            <ListGroup.Item className={highlightClass(5)}>
-              <strong>Poziom 5 – Optymalizujący</strong>
-              <div>Twoja organizacja działa w trybie ciągłego doskonalenia: regularnie identyfikujecie słabe ogniwa, eksperymentujecie z ulepszeniami i wdrażacie innowacje, które podnoszą efektywność. Zespoły samodzielnie proponują usprawnienia, a kultura organizacyjna sprzyja szybkiemu testowaniu i skalowaniu najlepszych praktyk.</div>
-            </ListGroup.Item>
-          </ListGroup>
-        </Card.Body>
-      </Card>
     </div>
   )
 }

--- a/frontend/src/components/__tests__/ResultsView.test.tsx
+++ b/frontend/src/components/__tests__/ResultsView.test.tsx
@@ -28,12 +28,12 @@ const results: Score[] = [
 
 describe('ResultsView', () => {
   it('shows scores with /5.0 suffix', async () => {
-    render(<ResultsView results={results} categories={[categories[0]]} />)
+    render(<ResultsView results={results} categories={[categories[0]]} onImprove={() => {}} />)
     expect(await screen.findByText('4/5.0')).toBeInTheDocument()
   })
 
   it('allows opening multiple categories', async () => {
-    render(<ResultsView results={results} categories={categories} />)
+    render(<ResultsView results={results} categories={categories} onImprove={() => {}} />)
     const user = userEvent.setup()
     await user.click(await screen.findByRole('button', { name: /Cat1/ }))
     await user.click(await screen.findByRole('button', { name: /Cat2/ }))
@@ -42,18 +42,26 @@ describe('ResultsView', () => {
   })
 
   it('shows subcategory averages', async () => {
-    render(<ResultsView results={results} categories={[categories[0]]} />)
+    render(<ResultsView results={results} categories={[categories[0]]} onImprove={() => {}} />)
     await userEvent.setup().click(await screen.findByRole('button', { name: /Cat1/ }))
     expect(await screen.findByText(/Sub1/)).toBeInTheDocument()
     expect((await screen.findAllByText('4.00/5.0')).length).toBeGreaterThan(0)
   })
 
   it('displays explanation section with highlighted levels', async () => {
-    render(<ResultsView results={results} categories={[categories[0]]} />)
+    render(<ResultsView results={results} categories={[categories[0]]} onImprove={() => {}} />)
     expect(await screen.findByRole('heading', { name: /Co oznacza mój wynik\?/ })).toBeInTheDocument()
     const lvl3 = screen.getByText(/Poziom 3/)
     const lvl4 = screen.getByText(/Poziom 4/)
     expect(lvl3.closest('.list-group-item')).toHaveClass('list-group-item-info')
     expect(lvl4.closest('.list-group-item')).toHaveClass('list-group-item-info')
+  })
+
+  it('calls onImprove when button clicked', async () => {
+    const fn = vi.fn()
+    render(<ResultsView results={results} categories={[categories[0]]} onImprove={fn} />)
+    const user = userEvent.setup()
+    await user.click(await screen.findByRole('button', { name: /Usprawnij procesy/ }))
+    expect(fn).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- include new `ProcessImprovement` page
- move explanation card above detailed results
- add navigation from results to improvement card
- adjust tests for new behaviour

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a7b4922d483319234395837846661