### PR TITLE
Implement process improvement prioritization UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -88,7 +88,11 @@ export default function App() {
 
   if (step === 'improvement') {
     return (
-      <ProcessImprovement onBack={() => setStep('results')} />
+      <ProcessImprovement
+        onBack={() => setStep('results')}
+        results={results}
+        categories={selectedCategories}
+      />
     )
   }
 

--- a/frontend/src/components/ProcessImprovement.tsx
+++ b/frontend/src/components/ProcessImprovement.tsx
@@ -1,15 +1,246 @@
-import { Container, Button } from 'react-bootstrap'
+import { useEffect, useState } from 'react'
+import {
+  Container,
+  Button,
+  Row,
+  Col,
+  Accordion,
+  ListGroup,
+  Form,
+  InputGroup,
+} from 'react-bootstrap'
+import { CategoryGroup, Score, Subcategory } from '../types'
+import { getSubcategories } from '../api/subcategories'
+
+interface Item {
+  id: string
+  type: 'category' | 'subcategory' | 'process'
+  name: string
+  score: number
+  parent?: string
+}
 
 interface Props {
   onBack: () => void
+  results: Score[]
+  categories: CategoryGroup[]
 }
 
-export default function ProcessImprovement({ onBack }: Props) {
+export default function ProcessImprovement({ onBack, results, categories }: Props) {
+  const [subcategories, setSubcategories] = useState<Subcategory[]>([])
+  const [selected, setSelected] = useState<string[]>([])
+  const [order, setOrder] = useState<string[]>([])
+  const [summary, setSummary] = useState('')
+  const [dragIndex, setDragIndex] = useState<number | null>(null)
+
+  useEffect(() => {
+    const ids = categories.flatMap(c => c.ids)
+    getSubcategories(ids).then(setSubcategories)
+  }, [categories])
+
+  const items: Record<string, Item> = {}
+
+  categories.forEach(c => {
+    const scores = results.filter(r => c.ids.includes(r.question.category_id))
+    const valid = scores.filter(r => r.value > 0)
+    const avg = valid.length ? valid.reduce((s, r) => s + r.value, 0) / valid.length : 0
+    const cid = `cat_${c.id}`
+    items[cid] = { id: cid, type: 'category', name: c.name, score: avg }
+    subcategories
+      .filter(sc => c.ids.includes(sc.category_id))
+      .forEach(sc => {
+        const scScores = scores.filter(s => s.question.subcategory_id === sc.id)
+        const scValid = scScores.filter(s => s.value > 0)
+        const scAvg = scValid.length ? scValid.reduce((s, r) => s + r.value, 0) / scValid.length : 0
+        const sid = `sub_${sc.category_id}_${sc.id}`
+        items[sid] = { id: sid, type: 'subcategory', name: sc.name, score: scAvg, parent: cid }
+        scScores.forEach(s => {
+          const qid = `proc_${s.question.category_id}_${s.question.subcategory_id}_${s.question.id}`
+          items[qid] = {
+            id: qid,
+            type: 'process',
+            name: s.question.description,
+            score: s.value,
+            parent: sid,
+          }
+        })
+      })
+  })
+
+  const getChildren = (id: string): string[] => {
+    const direct = Object.values(items).filter(i => i.parent === id).map(i => i.id)
+    return direct.reduce<string[]>((acc, c) => [...acc, c, ...getChildren(c)], [])
+  }
+
+  const toggle = (id: string) => {
+    const remove = (ids: string[], target: string[]) => ids.filter(i => !target.includes(i))
+    const toRemove = [id, ...getChildren(id)]
+    setSelected(prev =>
+      prev.includes(id) ? remove(prev, toRemove) : [...remove(prev, toRemove), id],
+    )
+    setOrder(prev =>
+      prev.includes(id)
+        ? remove(prev, toRemove)
+        : [...remove(prev, toRemove), id],
+    )
+  }
+
+  const hasParentSelected = (id: string): boolean => {
+    const item = items[id]
+    if (!item || !item.parent) return false
+    if (selected.includes(item.parent)) return true
+    return hasParentSelected(item.parent)
+  }
+
+  const typeLabel = (t: Item['type']) =>
+    t === 'category' ? 'Kategoria' : t === 'subcategory' ? 'Podkategoria' : 'Proces'
+
+  const handleDragOver = (idx: number) => {
+    if (dragIndex === null || dragIndex === idx) return
+    setOrder(prev => {
+      const arr = [...prev]
+      const [m] = arr.splice(dragIndex, 1)
+      arr.splice(idx, 0, m)
+      setDragIndex(idx)
+      return arr
+    })
+  }
+
+  const generateSummary = () => {
+    const lines: string[] = []
+    const details: string[] = []
+    order.forEach((id, idx) => {
+      const item = items[id]
+      if (!item) return
+      lines.push(`${idx + 1} ${typeLabel(item.type)} ${item.name}`)
+      const children = getChildren(id)
+      if (children.length) {
+        const names = children.map(cid => items[cid].name).join(', ')
+        details.push(`${typeLabel(item.type)} ${item.name}: ${names}`)
+      }
+    })
+    setSummary(lines.join('\n') + '\n\n' + details.join('\n'))
+  }
+
+  const copySummary = () => {
+    navigator.clipboard.writeText(summary)
+  }
+
   return (
-    <Container className="mt-4 d-flex flex-column align-items-center">
-      <h2 className="mb-3">Usprawnienie procesów</h2>
-      <p>Tutaj pojawią się wskazówki dotyczące usprawniania procesów.</p>
-      <Button className="mt-3" onClick={onBack}>Powrót</Button>
+    <Container className="mt-4">
+      <h2 className="mb-3 text-center">Usprawnienie procesów</h2>
+      <Row>
+        <Col md={6}>
+          <Accordion alwaysOpen>
+            {categories.map((c, idx) => {
+              const cid = `cat_${c.id}`
+              const cat = items[cid]
+              return (
+                <Accordion.Item eventKey={String(idx)} key={cid}>
+                  <Accordion.Header>
+                    <Form.Check
+                      type="checkbox"
+                      className="me-2"
+                      checked={selected.includes(cid)}
+                      onChange={() => toggle(cid)}
+                      aria-label={c.name}
+                    />
+                    {c.name} – {cat ? cat.score.toFixed(2) : '0.00'}/5.0
+                  </Accordion.Header>
+                  <Accordion.Body>
+                    {subcategories
+                      .filter(sc => c.ids.includes(sc.category_id))
+                      .map(sc => {
+                        const sid = `sub_${sc.category_id}_${sc.id}`
+                        const sub = items[sid]
+                        return (
+                          <div key={sid} className="mb-3 ms-3">
+                            <Form.Check
+                              type="checkbox"
+                              label={`${sc.name} – ${sub ? sub.score.toFixed(2) : '0.00'}/5.0`}
+                              id={sid}
+                              checked={selected.includes(sid)}
+                              disabled={hasParentSelected(sid)}
+                              onChange={() => toggle(sid)}
+                            />
+                            <ListGroup className="mt-2 ms-4">
+                              {results
+                                .filter(r =>
+                                  r.question.category_id === sc.category_id &&
+                                  r.question.subcategory_id === sc.id,
+                                )
+                                .map(r => {
+                                  const pid = `proc_${r.question.category_id}_${r.question.subcategory_id}_${r.question.id}`
+                                  return (
+                                    <ListGroup.Item key={pid} className="d-flex align-items-center">
+                                      <Form.Check
+                                        type="checkbox"
+                                        className="me-2"
+                                        checked={selected.includes(pid)}
+                                        disabled={hasParentSelected(pid)}
+                                        onChange={() => toggle(pid)}
+                                        label={
+                                          <span className="me-2">{r.question.description}</span>
+                                        }
+                                      />
+                                      <span className="ms-auto">
+                                        {r.value > 0 ? `${r.value}/5.0` : 'N/D'}
+                                      </span>
+                                    </ListGroup.Item>
+                                  )
+                                })}
+                            </ListGroup>
+                          </div>
+                        )
+                      })}
+                  </Accordion.Body>
+                </Accordion.Item>
+              )
+            })}
+          </Accordion>
+        </Col>
+        <Col md={6}>
+          <h5>Priorytety</h5>
+          <ListGroup>
+            {order.map((id, idx) => {
+              const item = items[id]
+              if (!item) return null
+              return (
+                <ListGroup.Item
+                  key={id}
+                  draggable
+                  onDragStart={() => setDragIndex(idx)}
+                  onDragOver={e => {
+                    e.preventDefault()
+                    handleDragOver(idx)
+                  }}
+                  onDrop={() => setDragIndex(null)}
+                  className="d-flex justify-content-between"
+                >
+                  <span>
+                    {idx + 1}. {typeLabel(item.type)} {item.name}
+                  </span>
+                  <span>{item.score > 0 ? `${item.score.toFixed(2)}/5.0` : 'N/D'}</span>
+                </ListGroup.Item>
+              )
+            })}
+          </ListGroup>
+          <Button className="mt-3" onClick={generateSummary}>
+            Generuj podsumowanie
+          </Button>
+          {summary && (
+            <InputGroup className="mt-3">
+              <Form.Control as="textarea" value={summary} readOnly rows={5} />
+              <Button variant="secondary" onClick={copySummary}>
+                Kopiuj
+              </Button>
+            </InputGroup>
+          )}
+        </Col>
+      </Row>
+      <div className="text-center mt-3">
+        <Button onClick={onBack}>Powrót</Button>
+      </div>
     </Container>
   )
 }

--- a/frontend/src/components/__tests__/ProcessImprovement.test.tsx
+++ b/frontend/src/components/__tests__/ProcessImprovement.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi, describe, it, expect } from 'vitest'
+import ProcessImprovement from '../ProcessImprovement'
+import { CategoryGroup, Score } from '../../types'
+
+vi.mock('../../api/subcategories', () => ({
+  getSubcategories: vi.fn(() => Promise.resolve([
+    { id: 1, name: 'Sub1', category_id: 1 }
+  ]))
+}))
+
+const category: CategoryGroup = { id: 1, name: 'Cat1', ids: [1] }
+const question = { id: 1, description: 'Proc1', category_id: 1, subcategory_id: 1 }
+const results: Score[] = [{ question, value: 4 }]
+
+describe('ProcessImprovement', () => {
+  it('handles hierarchical selection and summary', async () => {
+    render(
+      <ProcessImprovement
+        onBack={() => {}}
+        results={results}
+        categories={[category]}
+      />
+    )
+    const user = userEvent.setup()
+    const catCheck = await screen.findByRole('checkbox', { name: /Cat1/ })
+    const subCheck = screen.getByRole('checkbox', { name: /Sub1/ })
+    await user.click(catCheck)
+    expect(subCheck).toBeDisabled()
+    await user.click(catCheck)
+    await user.click(subCheck)
+    expect(screen.getByText(/Podkategoria Sub1/)).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /Generuj/ }))
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    expect(textarea.value).toContain('1 Podkategoria Sub1')
+  })
+})


### PR DESCRIPTION
## Summary
- extend `ProcessImprovement` component to display scored items with drag & drop
- allow selecting categories, subcategories and processes using checkboxes
- generate textual summary with copy button
- wire up `ProcessImprovement` with results in `App`
- add corresponding unit test

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a94c006448331b561c64684771fe4