### PR TITLE
Update highlighting in results explanation

### DIFF
--- a/frontend/src/components/ResultsView.tsx
+++ b/frontend/src/components/ResultsView.tsx
@@ -45,10 +45,11 @@ export default function ResultsView({ results, categories, onImprove }: Props) {
 
   const highlightLevels = () => {
     if (overall <= 0) return [] as number[]
-    const base = Math.floor(overall)
-    if (base >= 5) return [5]
-    const lvl = Math.max(1, base)
-    return [lvl, lvl + 1]
+    const levels: number[] = []
+    for (let lvl = 1; lvl <= 5; lvl++) {
+      if (lvl >= overall - 0.5 && lvl < overall + 1) levels.push(lvl)
+    }
+    return levels
   }
 
   const highlightClass = (level: number) =>


### PR DESCRIPTION
## Summary
- update highlight logic for explanation interval using <x-0.5, x+1)
- keep `list-group-item-info` style for highlighted levels
- align tests with restored style

## Testing
- `npm install` *(runs in frontend folder to install dependencies)*
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685a9ec6c9d0833188660d9f15e535da