### PR TITLE
Add workshop questionnaire step

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import CategoryForm from './components/CategoryForm'
 import ResultsView from './components/ResultsView'
 import ProcessImprovement from './components/ProcessImprovement'
 import MetadataForm from './components/MetadataForm'
+import WorkshopForm, { WorkshopData } from './components/WorkshopForm'
 import ReportView from './components/ReportView'
 import IntroPage from './components/IntroPage'
 import { createAssessment } from './api/assessments'
@@ -11,11 +12,12 @@ import { CategoryGroup, Score } from './types'
 import { Container, Button } from 'react-bootstrap'
 
 export default function App() {
-  const [step, setStep] = useState<'intro' | 'start' | 'categories' | 'questions' | 'results' | 'improvement' | 'report'>('intro')
+  const [step, setStep] = useState<'intro' | 'start' | 'categories' | 'questions' | 'results' | 'workshop' | 'improvement' | 'report'>('intro')
   const [selectedCategories, setSelectedCategories] = useState<CategoryGroup[]>([])
   const [currentIndex, setCurrentIndex] = useState(0)
   const [results, setResults] = useState<Score[]>([])
   const [metadata, setMetadata] = useState<{ employees_range: string; volunteers_range: string } | null>(null)
+  const [workshop, setWorkshop] = useState<WorkshopData | null>(null)
 
   useEffect(() => {
     if (step === 'results' && metadata) {
@@ -80,9 +82,15 @@ export default function App() {
     return (
       <Container className="mt-4 d-flex flex-column align-items-center">
         <h2 className="mb-3">Wyniki</h2>
-        <ResultsView results={results || []} categories={selectedCategories} onImprove={() => setStep('improvement')} />
+        <ResultsView results={results || []} categories={selectedCategories} onImprove={() => setStep('workshop')} />
         <Button className="mt-3" onClick={() => setStep('intro')}>Strona główna</Button>
       </Container>
+    )
+  }
+
+  if (step === 'workshop') {
+    return (
+      <WorkshopForm onSubmit={data => { setWorkshop(data); setStep('improvement') }} />
     )
   }
 

--- a/frontend/src/components/WorkshopForm.tsx
+++ b/frontend/src/components/WorkshopForm.tsx
@@ -1,0 +1,70 @@
+import { useForm, Controller } from 'react-hook-form'
+import { Form, Button, Container, InputGroup } from 'react-bootstrap'
+
+export interface WorkshopData {
+  area: string
+  budget: string
+  hours: string
+  participants: string
+}
+
+interface Props {
+  onSubmit: (data: WorkshopData) => void
+}
+
+export default function WorkshopForm({ onSubmit }: Props) {
+  const { control, handleSubmit } = useForm<WorkshopData>({})
+  const submit = handleSubmit(data => onSubmit(data))
+
+  return (
+    <Container className="mt-4 d-flex flex-column align-items-center">
+      <h2 className="mb-3">Kwestionariusz warsztatowy</h2>
+      <Form onSubmit={submit} className="w-100" style={{ maxWidth: '500px' }}>
+        <Form.Group className="mb-3" controlId="area">
+          <Form.Label>Obszar działania</Form.Label>
+          <Controller
+            name="area"
+            control={control}
+            defaultValue=""
+            render={({ field }) => <Form.Control {...field} required />}
+          />
+        </Form.Group>
+        <Form.Group className="mb-3" controlId="budget">
+          <Form.Label>Budżet na szkolenia i narzędzia (PLN)</Form.Label>
+          <Controller
+            name="budget"
+            control={control}
+            defaultValue=""
+            render={({ field }) => (
+              <InputGroup>
+                <InputGroup.Text>PLN</InputGroup.Text>
+                <Form.Control {...field} placeholder="np. 10000" required />
+              </InputGroup>
+            )}
+          />
+        </Form.Group>
+        <Form.Group className="mb-3" controlId="hours">
+          <Form.Label>Czas zespołu na warsztaty (godziny)</Form.Label>
+          <Controller
+            name="hours"
+            control={control}
+            defaultValue=""
+            render={({ field }) => <Form.Control {...field} required />}
+          />
+        </Form.Group>
+        <Form.Group className="mb-4" controlId="participants">
+          <Form.Label>Liczba uczestników warsztatów</Form.Label>
+          <Controller
+            name="participants"
+            control={control}
+            defaultValue=""
+            render={({ field }) => <Form.Control {...field} required />}
+          />
+        </Form.Group>
+        <div className="text-center">
+          <Button type="submit">Dalej</Button>
+        </div>
+      </Form>
+    </Container>
+  )
+}

--- a/frontend/src/components/__tests__/WorkshopForm.test.tsx
+++ b/frontend/src/components/__tests__/WorkshopForm.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import WorkshopForm from '../WorkshopForm'
+
+describe('WorkshopForm', () => {
+  it('submits entered values', async () => {
+    const submit = vi.fn()
+    render(<WorkshopForm onSubmit={submit} />)
+    const user = userEvent.setup()
+
+    await user.type(screen.getByLabelText(/Obszar działania/), 'IT')
+    await user.type(screen.getByLabelText(/Budżet/), '5000')
+    await user.type(screen.getByLabelText(/Czas zespołu/), '10')
+    await user.type(screen.getByLabelText(/Liczba uczestników/), '5')
+
+    await user.click(screen.getByRole('button', { name: /Dalej/ }))
+    expect(submit).toHaveBeenCalledWith({
+      area: 'IT',
+      budget: '5000',
+      hours: '10',
+      participants: '5',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- introduce WorkshopForm component for pre-workshop questionnaire
- insert new 'workshop' step in App flow
- update ResultsView navigation to show questionnaire before improvement list
- add unit test for WorkshopForm

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685aa9d40d788331a957482ece1fdb0b