### PR TITLE
Update workshop intro and remove report buttons

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,7 +27,7 @@ export default function App() {
 
   if (step === 'intro') {
     return (
-      <IntroPage onStart={() => setStep('start')} onReport={() => setStep('report')} />
+      <IntroPage onStart={() => setStep('start')} />
     )
   }
 
@@ -36,7 +36,6 @@ export default function App() {
       <Container className="mt-4 d-flex flex-column align-items-center">
         <h2 className="mb-3">Metryczka</h2>
         <MetadataForm onSubmit={(m) => { setMetadata(m); setStep('categories') }} />
-        <Button variant="link" className="mt-3" onClick={() => setStep('report')}>Raporty</Button>
       </Container>
     )
   }

--- a/frontend/src/components/IntroPage.tsx
+++ b/frontend/src/components/IntroPage.tsx
@@ -2,10 +2,9 @@ import { Container, Button } from 'react-bootstrap'
 
 interface Props {
   onStart: () => void
-  onReport: () => void
 }
 
-export default function IntroPage({ onStart, onReport }: Props) {
+export default function IntroPage({ onStart }: Props) {
   return (
     <Container className="mt-4 text-center d-flex flex-column align-items-center">
       <h1>Badanie samooceny</h1>
@@ -16,7 +15,6 @@ export default function IntroPage({ onStart, onReport }: Props) {
       </p>
       <div className="d-flex gap-2 mt-3">
         <Button onClick={onStart}>Rozpocznij badanie</Button>
-        <Button variant="secondary" onClick={onReport}>Raporty</Button>
       </div>
     </Container>
   )

--- a/frontend/src/components/WorkshopForm.tsx
+++ b/frontend/src/components/WorkshopForm.tsx
@@ -19,6 +19,7 @@ export default function WorkshopForm({ onSubmit }: Props) {
   return (
     <Container className="mt-4 d-flex flex-column align-items-center">
       <h2 className="mb-3">Kwestionariusz warsztatowy</h2>
+      <p className="mb-3">Żeby lepiej zrozumieć Twoje potrzeby, musimy się lepiej poznać.</p>
       <Form onSubmit={submit} className="w-100" style={{ maxWidth: '500px' }}>
         <Form.Group className="mb-3" controlId="area">
           <Form.Label>Obszar działania</Form.Label>

--- a/frontend/src/components/__tests__/IntroPage.test.tsx
+++ b/frontend/src/components/__tests__/IntroPage.test.tsx
@@ -6,7 +6,7 @@ import IntroPage from '../IntroPage'
 describe('IntroPage', () => {
   it('calls onStart when button clicked', async () => {
     const start = vi.fn()
-    render(<IntroPage onStart={start} onReport={() => {}} />)
+    render(<IntroPage onStart={start} />)
     const user = userEvent.setup()
     await user.click(screen.getByRole('button', { name: /Rozpocznij/ }))
     expect(start).toHaveBeenCalled()


### PR DESCRIPTION
## Summary
- remove `Raporty` buttons from intro/start pages
- adjust `IntroPage` component and tests
- add intro copy to Workshop form

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aaf2707208331b12a50ecd94ba700