### PR TITLE
Improve copy on metadata page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,8 +34,17 @@ export default function App() {
   if (step === 'start') {
     return (
       <Container className="mt-4 d-flex flex-column align-items-center">
-        <h2 className="mb-3">Metryczka</h2>
+        <h2 className="mb-3">Metryczka organizacji</h2>
+        <p className="text-center mb-3">
+          Kilka kluczowych informacji o Twojej organizacji pozwoli nam
+          przygotować spersonalizowane rekomendacje i wsparcie.
+        </p>
+        <h4 className="mb-3">Liczebność zespołu</h4>
         <MetadataForm onSubmit={(m) => { setMetadata(m); setStep('categories') }} />
+        <p className="text-center mt-3">
+          Podaj nam te dane, żebyśmy mogli lepiej zrozumieć kontekst Twojej
+          organizacji i dostarczyć Ci jak najlepsze rozwiązania!
+        </p>
       </Container>
     )
   }

--- a/frontend/src/components/MetadataForm.tsx
+++ b/frontend/src/components/MetadataForm.tsx
@@ -11,17 +11,17 @@ export default function MetadataForm({ onSubmit }: Props) {
     onSubmit(data as any)
   })
 
-  const empOptions = ['0-10', '11-50', '51-250', '251+']
-  const volOptions = ['0', '1-9', '10-49', '50+']
+  const empOptions = ['0–10', '11–50', '51–250', '251+']
+  const volOptions = ['0', '1–9', '10–49', '50+']
 
   return (
     <Form onSubmit={submit} className="w-100">
       <Form.Group className="mb-3">
-        <Form.Label>Liczba pracowników</Form.Label>
+        <Form.Label>Pracownicy</Form.Label>
         <Controller
           name="employees_range"
           control={control}
-          defaultValue="0-10"
+          defaultValue="0–10"
           render={({ field }) => (
             <Form.Select {...field}>
               {empOptions.map(o => <option key={o} value={o}>{o}</option>)}
@@ -30,7 +30,7 @@ export default function MetadataForm({ onSubmit }: Props) {
         />
       </Form.Group>
       <Form.Group className="mb-3">
-        <Form.Label>Liczba wolontariuszy</Form.Label>
+        <Form.Label>Wolontariusze</Form.Label>
         <Controller
           name="volunteers_range"
           control={control}


### PR DESCRIPTION
## Summary
- polish the copy displayed on the organization metadata page
- use nicer wording for employee and volunteer labels

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab2efe3908331abb0730039a4f0fa